### PR TITLE
Debug RPT spam fix

### DIFF
--- a/admiral/debug_functions.sqf
+++ b/admiral/debug_functions.sqf
@@ -117,16 +117,16 @@ adm_debug_fnc_updateCqcGroupMarkers = {
 
     {
         DECLARE(_debugMarker) = _x getVariable "adm_unit_debugMarker";
-        if (alive _x) then {
-            if (!isNil {_debugMarker}) then {
+        if (!isNil {_debugMarker}) then {
+            if (alive _x) then {
                 _debugMarker setMarkerPosLocal (getPosATL _x);
                 _debugMarker setMarkerDirLocal getDir _x;
                 DEBUG("admiral.debug",FMT_3("Updated CQC unit marker '%1' of unit '%2' in group '%3'.",_debugMarker,_x,_group));
             } else {
-                [_x, _group] call adm_debug_fnc_createCqcUnitMarker;
+               [_x, _debugMarker] call adm_debug_fnc_deleteCqcUnitMarker;
             };
         } else {
-            [_x, _debugMarker] call adm_debug_fnc_deleteCqcUnitMarker;
+            [_x, _group] call adm_debug_fnc_createCqcUnitMarker; 
         };
     } foreach units _group;
 };


### PR DESCRIPTION
Fix for #29, old logic was "if unit is not alive, delete _marker", regardless of whether _marker is nil or not, causes looping rpt spam once _marker is nil.