### PR TITLE
Run publicVariable on debug var if in MP

### DIFF
--- a/admiral/admiral_postinit_start.sqf
+++ b/admiral/admiral_postinit_start.sqf
@@ -8,6 +8,7 @@
 
 if (isMultiplayer) then {
     adm_isDebuggingEnabled = false;
+    publicVariable "adm_isDebuggingEnabled";
 };
 
 [] call adm_settings_fnc_init; DEBUG("admiral.settings","Init function 'adm_settings_fnc_init' called.");


### PR DESCRIPTION
Cannot hide Activate/Deactivate options using adm_isDebuggingEnabled since the value is nil on the client. This simple addition should rectify it. In SP it works fine since server = client.

Ref: https://i.imgur.com/oCHZHMd.jpg?1