### PR TITLE
Unit template updates

### DIFF
--- a/admiral/unit_templates.h
+++ b/admiral/unit_templates.h
@@ -9,7 +9,7 @@ class UnitTemplates {
 
     class NATO_WOODLAND {
         side = "west";
-        infantry[] = {"B_Soldier_F", "B_Soldier_02_f", "B_Soldier_03_f", "B_soldier_AR_F", "B_Soldier_TL_F", "B_HeavyGunner_F", "B_medic_F", "B_soldier_AR_F", "B_soldier_LAT_F"};
+        infantry[] = {"B_Soldier_TL_F", "B_soldier_AR_F", "B_Soldier_F", "B_soldier_LAT_F", "B_HeavyGunner_F", "B_soldier_AR_F", "B_soldier_LAT_F", "B_soldier_AR_F", "B_soldier_LAT_F"};
         crewmen[] = {"B_crew_F", "B_engineer_F"};
         technicals[] = {"B_MRAP_01_hmg_F"};
         armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
@@ -17,7 +17,7 @@ class UnitTemplates {
 
     class MNP_USMC_WD {
         side = "west";
-        infantry[] = {"MNP_USMC_Soldier_F", "MNP_USMC_Soldier_F", "MNP_USMC_Soldier_F", "MNP_USMC_Soldier_AR", "MNP_USMC_Soldier_O", "MNP_USMC_Soldier_MG", "MNP_USMC_Soldier_Med", "MNP_USMC_Soldier_AR", "MNP_USMC_Soldier_AT"};
+        infantry[] = {"MNP_USMC_Soldier_O", "MNP_USMC_Soldier_AR", "MNP_USMC_Soldier_F", "MNP_USMC_Soldier_AT", "MNP_USMC_Soldier_MG", "MNP_USMC_Soldier_AR", "MNP_USMC_Soldier_AT", "MNP_USMC_Soldier_AR", "MNP_USMC_Soldier_AT"};
         crewmen[] = {"MNP_USMC_Soldier_F", "MNP_USMC_Soldier_O"};
         technicals[] = {"B_MRAP_01_hmg_F"};
         armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
@@ -25,7 +25,7 @@ class UnitTemplates {
 
     class MNP_USMC_DE {
         side = "west";
-        infantry[] = {"MNP_USMC_Soldier_DF", "MNP_USMC_Soldier_DF", "MNP_USMC_Soldier_DF", "MNP_USMC_Soldier_DAR", "MNP_USMC_Soldier_DO", "MNP_USMC_Soldier_DMG", "MNP_USMC_Soldier_DMed", "MNP_USMC_Soldier_DAR", "MNP_USMC_Soldier_DAT"};
+        infantry[] = {"MNP_USMC_Soldier_DO", "MNP_USMC_Soldier_DAR", "MNP_USMC_Soldier_DF", "MNP_USMC_Soldier_DAT", "MNP_USMC_Soldier_DMG", "MNP_USMC_Soldier_DAR", "MNP_USMC_Soldier_DAT", "MNP_USMC_Soldier_DAR", "MNP_USMC_Soldier_DAT"};
         crewmen[] = {"MNP_USMC_Soldier_DF", "MNP_USMC_Soldier_DO"};
         technicals[] = {"B_MRAP_01_hmg_F"};
         armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
@@ -33,7 +33,7 @@ class UnitTemplates {
 
     class MNP_USMC_SN {
         side = "west";
-        infantry[] = {"MNP_USMCA_Soldier_F", "MNP_USMCA_Soldier_F", "MNP_USMCA_Soldier_F", "MNP_USMCA_Soldier_AR", "MNP_USMCA_Soldier_O", "MNP_USMCA_Soldier_MG", "MNP_USMCA_Soldier_MD", "MNP_USMCA_Soldier_AR", "MNP_USMCA_Soldier_AT"};
+        infantry[] = {"MNP_USMCA_Soldier_O", "MNP_USMCA_Soldier_AR", "MNP_USMCA_Soldier_F", "MNP_USMCA_Soldier_AT", "MNP_USMCA_Soldier_MG", "MNP_USMCA_Soldier_AR", "MNP_USMCA_Soldier_AT", "MNP_USMCA_Soldier_AR", "MNP_USMCA_Soldier_AT"};
         crewmen[] = {"MNP_USMCA_Soldier_F", "MNP_USMCA_Soldier_O"};
         technicals[] = {"B_MRAP_01_hmg_F"};
         armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
@@ -41,7 +41,7 @@ class UnitTemplates {
 
     class MNP_US_RAN {
         side = "west";
-        infantry[] = {"MNP_USR_Soldier_F", "MNP_USR_Soldier_F", "MNP_USR_Soldier_F", "MNP_USR_Soldier_AR", "MNP_USR_Soldier_O", "MNP_USR_Soldier_MG", "MNP_USR_Soldier_M", "MNP_USR_Soldier_AR", "MNP_USR_Soldier_AT"};
+        infantry[] = {"MNP_USR_Soldier_O", "MNP_USR_Soldier_AR", "MNP_USR_Soldier_F", "MNP_USR_Soldier_AT", "MMG", "MNP_USR_Soldier_AR", "MNP_USR_Soldier_AT", "MNP_USR_Soldier_AR", "MNP_USR_Soldier_AT"};
         crewmen[] = {"MNP_USR_Soldier_F", "MNP_USR_Soldier_O"};
         technicals[] = {"B_MRAP_01_hmg_F"};
         armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
@@ -49,7 +49,7 @@ class UnitTemplates {
 
     class MNP_US_ACU {
         side = "west";
-        infantry[] = {"MNP_USA_Soldier_F", "MNP_USA_Soldier_F", "MNP_USA_Soldier_F", "MNP_USA_Soldier_AR", "MNP_USA_Soldier_O", "MNP_USA_Soldier_MG", "MNP_USA_Soldier_MED", "MNP_USA_Soldier_AR", "MNP_USA_Soldier_AT"};
+        infantry[] = {"MNP_USA_Soldier_O", "MNP_USA_Soldier_AR", "MNP_USA_Soldier_F", "MNP_USA_Soldier_AT", "MNP_USA_Soldier_MG", "MNP_USA_Soldier_AR", "MNP_USA_Soldier_AT", "MNP_USA_Soldier_AR", "MNP_USA_Soldier_AT"};
         crewmen[] = {"MNP_USA_Soldier_F", "MNP_USA_Soldier_O"};
         technicals[] = {"B_MRAP_01_hmg_F"};
         armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
@@ -57,7 +57,7 @@ class UnitTemplates {
 
     class MNP_US_WD {
         side = "west";
-        infantry[] = {"MNP_Wood_Soldier_F", "MNP_M81_Soldier_F", "MNP_Wood_Soldier_F", "MNP_M81_Soldier_AR", "MNP_Wood_Soldier_O", "MNP_M81_Soldier_MG", "MNP_M81_Soldier_Md", "MNP_M81_Soldier_AR", "MNP_M81_Soldier_AT"};
+        infantry[] = {"MNP_Wood_Soldier_O", "MNP_M81_Soldier_AR", "MNP_Wood_Soldier_F", "MNP_M81_Soldier_AT", "MNP_M81_Soldier_MG", "MNP_M81_Soldier_AR", "MNP_M81_Soldier_AT", "MNP_M81_Soldier_AR", "MNP_M81_Soldier_AT"};
         crewmen[] = {"MNP_M81_Soldier_F", "MNP_M81_Soldier_O"};
         technicals[] = {"B_MRAP_01_hmg_F"};
         armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
@@ -65,7 +65,7 @@ class UnitTemplates {
 
     class MNP_US_DE {
         side = "west";
-        infantry[] = {"MNP_3Co_Soldier_F2", "MNP_3Co_Soldier_F", "MNP_3Co_Soldier_F2", "MNP_3Co_Soldier_AR", "MNP_3Co_Soldier_O2", "MNP_3Co_Soldier_MG", "MNP_3Co_Soldier_Md", "MNP_3Co_Soldier_AR", "MNP_3Co_Soldier_AT"};
+        infantry[] = {"MNP_3Co_Soldier_O2", "MNP_3Co_Soldier_AR", "MNP_3Co_Soldier_F2", "MNP_3Co_Soldier_AT", "MNP_3Co_Soldier_MG", "MNP_3Co_Soldier_AR", "MNP_3Co_Soldier_AT", "MNP_3Co_Soldier_AR", "MNP_3Co_Soldier_AT"};
         crewmen[] = {"MNP_3Co_Soldier_F", "MNP_3Co_Soldier_O"};
         technicals[] = {"B_MRAP_01_hmg_F"};
         armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
@@ -73,7 +73,7 @@ class UnitTemplates {
 
     class MNP_GE_WD {
         side = "west";
-        infantry[] = {"MNP_GER_Soldier_F", "MNP_GER_Soldier_F", "MNP_GER_Soldier_F", "MNP_GER_Soldier_AR", "MNP_GER_Soldier_S", "MNP_GER_Soldier_MG", "MNP_GER_Soldier_MED", "MNP_GER_Soldier_AR", "MNP_GER_Soldier_AT"};
+        infantry[] = {"MNP_GER_Soldier_S", "MNP_GER_Soldier_AR", "MNP_GER_Soldier_F", "MNP_GER_Soldier_AT", "MNP_GER_Soldier_MG", "MNP_GER_Soldier_AR", "MNP_GER_Soldier_AT", "MNP_GER_Soldier_AR", "MNP_GER_Soldier_AT"};
         crewmen[] = {"MNP_GER_Soldier_F", "MNP_GER_Soldier_S"};
         technicals[] = {"B_MRAP_01_hmg_F"};
         armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
@@ -81,7 +81,7 @@ class UnitTemplates {
 
     class MNP_GE_DE {
         side = "west";
-        infantry[] = {"MNP_GER_Soldier_DF", "MNP_GER_Soldier_DF", "MNP_GER_Soldier_DF", "MNP_GER_Soldier_AR_D", "MNP_GER_Soldier_DS", "MNP_GER_Soldier_MG_D", "MNP_GER_Soldier_MED_D", "MNP_GER_Soldier_AR_D", "MNP_GER_Soldier_AT_D"};
+        infantry[] = {"MNP_GER_Soldier_DS", "MNP_GER_Soldier_AR_D", "MNP_GER_Soldier_DF", "MNP_GER_Soldier_AT_D", "MNP_GER_Soldier_MG_D", "MNP_GER_Soldier_AR_D", "MNP_GER_Soldier_AT_D", "MNP_GER_Soldier_AR_D", "MNP_GER_Soldier_AT_D"};
         crewmen[] = {"MNP_GER_Soldier_DF", "MNP_GER_Soldier_DS"};
         technicals[] = {"B_MRAP_01_hmg_F"};
         armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
@@ -89,7 +89,7 @@ class UnitTemplates {
 
     class MNP_CA_WD {
         side = "west";
-        infantry[] = {"MNP_Canada_Soldier_F", "MNP_Canada_Soldier_F", "MNP_Canada_Soldier_F", "MNP_Canada_Soldier_AR", "MNP_Canada_Soldier_S", "MNP_Canada_Soldier_MG", "MNP_Canada_Soldier_M", "MNP_Canada_Soldier_AR", "MNP_Canada_Soldier_AT"};
+        infantry[] = {"MNP_Canada_Soldier_S", "MNP_Canada_Soldier_AR", "MNP_Canada_Soldier_F", "MNP_Canada_Soldier_AT", "MNP_Canada_Soldier_MG", "MNP_Canada_Soldier_AR", "MNP_Canada_Soldier_AT", "MNP_Canada_Soldier_AR", "MNP_Canada_Soldier_AT"};
         crewmen[] = {"MNP_Canada_Soldier_F", "MNP_Canada_Soldier_S"};
         technicals[] = {"B_MRAP_01_hmg_F"};
         armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
@@ -97,7 +97,7 @@ class UnitTemplates {
 
     class MNP_CA_DE {
         side = "west";
-        infantry[] = {"MNP_Canada_Soldier_DF", "MNP_Canada_Soldier_DF", "MNP_Canada_Soldier_DF", "MNP_Canada_Soldier_DAR", "MNP_Canada_Soldier_DS", "MNP_Canada_Soldier_DMG", "MNP_Canada_Soldier_DM", "MNP_Canada_Soldier_DAR", "MNP_Canada_Soldier_DAT"};
+        infantry[] = {"MNP_Canada_Soldier_DS", "MNP_Canada_Soldier_DAR", "MNP_Canada_Soldier_DF", "MNP_Canada_Soldier_DAT", "MNP_Canada_Soldier_DMG", "MNP_Canada_Soldier_DAR", "MNP_Canada_Soldier_DAT", "MNP_Canada_Soldier_DAR", "MNP_Canada_Soldier_DAT"};
         crewmen[] = {"MNP_Canada_Soldier_DF", "MNP_Canada_Soldier_DS"};
         technicals[] = {"B_MRAP_01_hmg_F"};
         armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
@@ -105,7 +105,7 @@ class UnitTemplates {
 
     class MNP_AUS {
         side = "west";
-        infantry[] = {"MNP_AUS_Soldier_F", "MNP_AUS_Soldier_F", "MNP_AUS_Soldier_F", "MNP_AUS_Soldier_AR", "MNP_AUS_Soldier_S", "MNP_AUS_Soldier_MG", "MNP_AUS_Soldier_MD", "MNP_AUS_Soldier_AR", "MNP_AUS_Soldier_AT"};
+        infantry[] = {"MNP_AUS_Soldier_S", "MNP_AUS_Soldier_AR", "MNP_AUS_Soldier_F", "MNP_AUS_Soldier_AT", "MNP_AUS_Soldier_MG", "MNP_AUS_Soldier_AR", "MNP_AUS_Soldier_AT", "MNP_AUS_Soldier_AR", "MNP_AUS_Soldier_AT"};
         crewmen[] = {"MNP_AUS_Soldier_F", "MNP_AUS_Soldier_S"};
         technicals[] = {"B_MRAP_01_hmg_F"};
         armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
@@ -113,7 +113,7 @@ class UnitTemplates {
 
     class MNP_ROK {
         side = "west";
-        infantry[] = {"MNP_ROK_Soldier_F", "MNP_ROK_Soldier_F", "MNP_ROK_Soldier_F", "MNP_ROK_Soldier_AR", "MNP_ROK_Soldier_O", "MNP_ROK_Soldier_MG", "MNP_ROK_Soldier_M", "MNP_ROK_Soldier_AR", "MNP_ROK_Soldier_AT"};
+        infantry[] = {"MNP_ROK_Soldier_O", "MNP_ROK_Soldier_AR", "MNP_ROK_Soldier_F", "MNP_ROK_Soldier_AT", "MNP_ROK_Soldier_MG", "MNP_ROK_Soldier_AR", "MNP_ROK_Soldier_AT", "MNP_ROK_Soldier_AR", "MNP_ROK_Soldier_AT"};
         crewmen[] = {"MNP_ROK_Soldier_F", "MNP_ROK_Soldier_O"};
         technicals[] = {"B_MRAP_01_hmg_F"};
         armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
@@ -121,7 +121,7 @@ class UnitTemplates {
 
     class MNP_PMC {
         side = "west";
-        infantry[] = {"MNP_OD_Soldier_F", "MNP_OD_Soldier_F", "MNP_OD_Soldier_F", "MNP_OD_Soldier_AR", "MNP_OD_Soldier_O", "MNP_OD_Soldier_MG", "MNP_OD_Soldier_Md", "MNP_OD_Soldier_AR", "MNP_OD_Soldier_AT"};
+        infantry[] = {"MNP_OD_Soldier_O", "MNP_OD_Soldier_AR", "MNP_OD_Soldier_F", "MNP_OD_Soldier_AT", "MNP_OD_Soldier_MG", "MNP_OD_Soldier_AR", "MNP_OD_Soldier_AT", "MNP_OD_Soldier_AR", "MNP_OD_Soldier_AT"};
         crewmen[] = {"MNP_OD_Soldier_F", "MNP_OD_Soldier_O"};
         technicals[] = {"B_MRAP_01_hmg_F"};
         armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
@@ -129,7 +129,7 @@ class UnitTemplates {
 
     class FIA_GUER {
         side = "west";
-        infantry[] = {"B_G_Soldier_F", "B_G_Soldier_lite_F", "B_G_Soldier_A_F", "B_G_Soldier_AR_F", "B_G_Soldier_TL_F", "B_G_Soldier_GL_F", "B_G_medic_F", "B_G_Soldier_AR_F", "B_G_Soldier_LAT_F"};
+        infantry[] = {"B_G_Soldier_TL_F", "B_G_Soldier_AR_F", "B_G_Soldier_lite_F", "B_G_Soldier_LAT_F", "B_G_Soldier_M_F", "B_G_Soldier_AR_F", "B_G_Soldier_LAT_F", "B_G_Soldier_AR_F", "B_G_Soldier_LAT_F"};
         crewmen[] = {"B_G_Soldier_F", "B_G_engineer_F"};
         technicals[] = {"B_G_Offroad_01_armed_F"};
         armour[] = {"B_G_Offroad_01_armed_F"};

--- a/admiral/unit_templates.h
+++ b/admiral/unit_templates.h
@@ -9,7 +9,7 @@ class UnitTemplates {
 
     class NATO_WOODLAND {
         side = "west";
-        infantry[] = {"B_Soldier_TL_F", "B_soldier_AR_F", "B_Soldier_F", "B_soldier_LAT_F", "B_HeavyGunner_F", "B_soldier_AR_F", "B_soldier_LAT_F", "B_soldier_AR_F", "B_soldier_LAT_F"};
+        infantry[] = {"B_Soldier_SL_F", "B_soldier_AR_F", "B_Soldier_F", "B_soldier_LAT_F", "B_HeavyGunner_F", "B_soldier_AR_F", "B_soldier_LAT_F", "B_soldier_AR_F", "B_soldier_LAT_F"};
         crewmen[] = {"B_crew_F", "B_engineer_F"};
         technicals[] = {"B_MRAP_01_hmg_F"};
         armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
@@ -129,7 +129,7 @@ class UnitTemplates {
 
     class FIA_GUER {
         side = "west";
-        infantry[] = {"B_G_Soldier_TL_F", "B_G_Soldier_AR_F", "B_G_Soldier_lite_F", "B_G_Soldier_LAT_F", "B_G_Soldier_M_F", "B_G_Soldier_AR_F", "B_G_Soldier_LAT_F", "B_G_Soldier_AR_F", "B_G_Soldier_LAT_F"};
+        infantry[] = {"B_G_Soldier_SL_F", "B_G_Soldier_AR_F", "B_G_Soldier_lite_F", "B_G_Soldier_LAT_F", "B_G_Soldier_M_F", "B_G_Soldier_AR_F", "B_G_Soldier_LAT_F", "B_G_Soldier_AR_F", "B_G_Soldier_LAT_F"};
         crewmen[] = {"B_G_Soldier_F", "B_G_engineer_F"};
         technicals[] = {"B_G_Offroad_01_armed_F"};
         armour[] = {"B_G_Offroad_01_armed_F"};
@@ -137,7 +137,7 @@ class UnitTemplates {
 
     class CSAT_WOODLAND {
         side = "east";
-        infantry[] = {"O_Soldier_TL_F", "O_Soldier_AR_F", "O_Soldier_lite_F", "O_Soldier_LAT_F", "O_support_MG_F", "O_Soldier_AR_F", "O_Soldier_LAT_F", "O_Soldier_AR_F", "O_Soldier_LAT_F"};
+        infantry[] = {"O_Soldier_SL_F", "O_Soldier_AR_F", "O_Soldier_lite_F", "O_Soldier_LAT_F", "O_support_MG_F", "O_Soldier_AR_F", "O_Soldier_LAT_F", "O_Soldier_AR_F", "O_Soldier_LAT_F"};
         crewmen[] = {"O_crew_F", "O_engineer_F"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -145,7 +145,7 @@ class UnitTemplates {
 
     class CSAT_URBAN {
         side = "east";
-        infantry[] = {"O_soldierU_TL_F", "O_soldierU_AR_F", "O_soldierU_F", "O_soldierU_LAT_F", "O_soldierU_M_F", "O_soldierU_AR_F", "O_soldierU_LAT_F", "O_soldierU_AR_F", "O_soldierU_LAT_F"};
+        infantry[] = {"O_soldierU_SL_F", "O_soldierU_AR_F", "O_soldierU_F", "O_soldierU_LAT_F", "O_soldierU_M_F", "O_soldierU_AR_F", "O_soldierU_LAT_F", "O_soldierU_AR_F", "O_soldierU_LAT_F"};
         crewmen[] = {"O_soldierU_F", "O_engineer_U_F"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -273,7 +273,7 @@ class UnitTemplates {
 
     class AAF_WOODLAND {
         side = "resistance";
-        infantry[] = {"I_Soldier_TL_F", "I_Soldier_AR_F", "I_Soldier_lite_F", "I_Soldier_LAT_F", "I_Soldier_M_F", "I_Soldier_AR_F", "I_Soldier_LAT_F", "I_Soldier_AR_F", "I_Soldier_LAT_F"};
+        infantry[] = {"I_Soldier_SL_F", "I_Soldier_AR_F", "I_Soldier_lite_F", "I_Soldier_LAT_F", "I_Soldier_M_F", "I_Soldier_AR_F", "I_Soldier_LAT_F", "I_Soldier_AR_F", "I_Soldier_LAT_F"};
         crewmen[] = {"I_crew_F", "I_engineer_F"};
         technicals[] = {"I_MRAP_03_hmg_F"};
         armour[] = {"I_APC_tracked_03_cannon_F", "I_MBT_03_cannon_F"};
@@ -281,7 +281,7 @@ class UnitTemplates {
 
     class AAF_DESERT {
         side = "resistance";
-        infantry[] = {"AAF_D_Soldier_TL_F", "AAF_D_Soldier_AR_F", "AAF_D_Soldier_lite_F", "AAF_D_Soldier_LAT_F", "AAF_D_Soldier_M_F", "AAF_D_Soldier_AR_F", "AAF_D_Soldier_LAT_F", "AAF_D_Soldier_AR_F", "AAF_D_Soldier_LAT_F"};
+        infantry[] = {"AAF_D_Soldier_SL_F", "AAF_D_Soldier_AR_F", "AAF_D_Soldier_lite_F", "AAF_D_Soldier_LAT_F", "AAF_D_Soldier_M_F", "AAF_D_Soldier_AR_F", "AAF_D_Soldier_LAT_F", "AAF_D_Soldier_AR_F", "AAF_D_Soldier_LAT_F"};
         crewmen[] = {"AAF_D_Soldier_crew_F", "AAF_D_Soldier_repair_F"};
         technicals[] = {"AAF_D_MRAP_03_hmg_F"};
         armour[] = {"AAF_D_APC_tracked_03_cannon_F", "AAF_D_MBT_03_cannon_F"};
@@ -393,7 +393,7 @@ class UnitTemplates {
 
     class AAF_GUER {
         side = "resistance";
-        infantry[] = {"I_G_Soldier_TL_F", "I_G_soldier_AR_F", "I_G_Soldier_lite_F", "I_G_soldier_LAT_F", "I_G_soldier_M_F", "I_G_soldier_AR_F", "I_G_soldier_LAT_F", "I_G_soldier_AR_F", "I_G_soldier_LAT_F"};
+        infantry[] = {"I_G_Soldier_SL_F", "I_G_soldier_AR_F", "I_G_Soldier_lite_F", "I_G_soldier_LAT_F", "I_G_soldier_M_F", "I_G_soldier_AR_F", "I_G_soldier_LAT_F", "I_G_soldier_AR_F", "I_G_soldier_LAT_F"};
         crewmen[] = {"I_G_Soldier_lite_F", "I_G_engineer_F"};
         technicals[] = {"I_G_Offroad_01_armed_F"};
         armour[] = {"I_G_Offroad_01_armed_F"};

--- a/admiral/unit_templates.h
+++ b/admiral/unit_templates.h
@@ -273,7 +273,7 @@ class UnitTemplates {
 
     class AAF_WOODLAND {
         side = "resistance";
-        infantry[] = {"I_soldier_F", "I_Soldier_lite_F", "I_Soldier_A_F", "I_Soldier_AR_F", "I_Soldier_TL_F", "I_Soldier_GL_F", "I_medic_F", "I_Soldier_AR_F", "I_Soldier_LAT_F"};
+        infantry[] = {"I_Soldier_TL_F", "I_Soldier_AR_F", "I_Soldier_lite_F", "I_Soldier_LAT_F", "I_Soldier_M_F", "I_Soldier_AR_F", "I_Soldier_LAT_F", "I_Soldier_AR_F", "I_Soldier_LAT_F"};
         crewmen[] = {"I_crew_F", "I_engineer_F"};
         technicals[] = {"I_MRAP_03_hmg_F"};
         armour[] = {"I_APC_tracked_03_cannon_F", "I_MBT_03_cannon_F"};
@@ -281,7 +281,7 @@ class UnitTemplates {
 
     class AAF_DESERT {
         side = "resistance";
-        infantry[] = {"AAF_D_Soldier_F", "AAF_D_Soldier_lite_F", "AAF_D_Soldier_F", "AAF_D_Soldier_AR_F", "AAF_D_Soldier_TL_F", "AAF_D_Soldier_GL_F", "AAF_D_Soldier_medic_F", "AAF_D_Soldier_AR_F", "AAF_D_Soldier_LAT_F"};
+        infantry[] = {"AAF_D_Soldier_TL_F", "AAF_D_Soldier_AR_F", "AAF_D_Soldier_lite_F", "AAF_D_Soldier_LAT_F", "AAF_D_Soldier_M_F", "AAF_D_Soldier_AR_F", "AAF_D_Soldier_LAT_F", "AAF_D_Soldier_AR_F", "AAF_D_Soldier_LAT_F"};
         crewmen[] = {"AAF_D_Soldier_crew_F", "AAF_D_Soldier_repair_F"};
         technicals[] = {"AAF_D_MRAP_03_hmg_F"};
         armour[] = {"AAF_D_APC_tracked_03_cannon_F", "AAF_D_MBT_03_cannon_F"};
@@ -289,7 +289,7 @@ class UnitTemplates {
 
     class MNP_MIL_WD {
         side = "resistance";
-        infantry[] = {"MNP_Militia_Soldier_F", "MNP_Militia_Soldier_F", "MNP_Militia_Soldier_F", "MNP_Militia_Soldier_AR", "MNP_Militia_Soldier_O", "MNP_Militia_Soldier_G", "MNP_Militia_Soldier_M", "MNP_Militia_Soldier_AR", "MNP_Militia_Soldier_RAT"};
+        infantry[] = {"MNP_Militia_Soldier_O", "MNP_Militia_Soldier_AR", "MNP_Militia_Soldier_F", "MNP_Militia_Soldier_RAT", "MNP_Militia_Soldier_MG", "MNP_Militia_Soldier_AR", "MNP_Militia_Soldier_RAT", "MNP_Militia_Soldier_AR", "MNP_Militia_Soldier_RAT"};
         crewmen[] = {"MNP_Militia_Soldier_F", "MNP_Militia_Soldier_O"};
         technicals[] = {"B_G_Offroad_01_armed_F"};
         armour[] = {"B_G_Offroad_01_armed_F"};
@@ -297,7 +297,7 @@ class UnitTemplates {
 
     class MNP_MIL_DE {
         side = "resistance";
-        infantry[] = {"MNP_Militia_Soldier_DF", "MNP_Militia_Soldier_DF", "MNP_Militia_Soldier_DF", "MNP_Militia_Soldier_DAR", "MNP_Militia_Soldier_DO", "MNP_Militia_Soldier_DMG", "MNP_Militia_Soldier_DM", "MNP_Militia_Soldier_DAR", "MNP_Militia_Soldier_DRAT"};
+        infantry[] = {"MNP_Militia_Soldier_DO", "MNP_Militia_Soldier_DAR", "MNP_Militia_Soldier_DF", "MNP_Militia_Soldier_DRAT", "MNP_Militia_Soldier_DMG", "MNP_Militia_Soldier_DAR", "MNP_Militia_Soldier_DRAT", "MNP_Militia_Soldier_DAR", "MNP_Militia_Soldier_DRAT"};
         crewmen[] = {"MNP_Militia_Soldier_DF", "MNP_Militia_Soldier_DO"};
         technicals[] = {"B_G_Offroad_01_armed_F"};
         armour[] = {"B_G_Offroad_01_armed_F"};
@@ -305,7 +305,7 @@ class UnitTemplates {
 
     class MNP_NPA_WD {
         side = "resistance";
-        infantry[] = {"MNP_DPM_Soldier_D", "MNP_DPM_Soldier_D", "MNP_DPM_Soldier_D", "MNP_DPM_Soldier_AR", "MNP_DPM_Soldier_O", "MNP_DPM_Soldier_MG", "MNP_DPM_Soldier_M", "MNP_DPM_Soldier_AR", "MNP_DPM_Soldier_AT"};
+        infantry[] = {"MNP_DPM_Soldier_O", "MNP_DPM_Soldier_AR", "MNP_DPM_Soldier_D", "MNP_DPM_Soldier_AT", "MNP_DPM_Soldier_MG", "MNP_DPM_Soldier_AR", "MNP_DPM_Soldier_AT", "MNP_DPM_Soldier_AR", "MNP_DPM_Soldier_AT"};
         crewmen[] = {"MNP_DPM_Soldier_D", "MNP_DPM_Soldier_O"};
         technicals[] = {"B_G_Offroad_01_armed_F"};
         armour[] = {"B_G_Offroad_01_armed_F"};
@@ -313,7 +313,7 @@ class UnitTemplates {
 
     class MNP_NPA_DE {
         side = "resistance";
-        infantry[] = {"MNP_SixCo_Soldier_D", "MNP_SixCo_Soldier_D", "MNP_SixCo_Soldier_D", "MNP_SixCo_Soldier_AR", "MNP_SixCo_Soldier_O", "MNP_SixCo_Soldier_MG", "MNP_SixCo_Soldier_M", "MNP_SixCo_Soldier_AR", "MNP_SixCo_Soldier_AT"};
+        infantry[] = {"MNP_SixCo_Soldier_O", "MNP_SixCo_Soldier_AR", "MNP_SixCo_Soldier_D", "MNP_SixCo_Soldier_AT", "MNP_SixCo_Soldier_MG", "MNP_SixCo_Soldier_AR", "MNP_SixCo_Soldier_AT", "MNP_SixCo_Soldier_AR", "MNP_SixCo_Soldier_AT"};
         crewmen[] = {"MNP_SixCo_Soldier_D", "MNP_SixCo_Soldier_O"};
         technicals[] = {"I_MRAP_03_hmg_F"};
         armour[] = {"I_APC_tracked_03_cannon_F", "I_MBT_03_cannon_F"};
@@ -321,7 +321,7 @@ class UnitTemplates {
 
     class MNP_ASA {
         side = "resistance";
-        infantry[] = {"MNP_ASA_Soldier_F", "MNP_ASA_Soldier_F", "MNP_ASA_Soldier_F", "MNP_ASA_Soldier_AR", "MNP_ASA_Soldier_O", "MNP_ASA_Soldier_MG", "MNP_ASA_Soldier_M", "MNP_ASA_Soldier_AR", "MNP_ASA_Soldier_AT"};
+        infantry[] = {"MNP_ASA_Soldier_O", "MNP_ASA_Soldier_AR", "MNP_ASA_Soldier_F", "MNP_ASA_Soldier_AT", "MNP_ASA_Soldier_MG", "MNP_ASA_Soldier_AR", "MNP_ASA_Soldier_AT", "MNP_ASA_Soldier_AR", "MNP_ASA_Soldier_AT"};
         crewmen[] = {"MNP_ASA_Soldier_F", "MNP_ASA_Soldier_O"};
         technicals[] = {"B_G_Offroad_01_armed_F"};
         armour[] = {"B_G_Offroad_01_armed_F"};
@@ -329,7 +329,7 @@ class UnitTemplates {
 
     class MNP_ARC {
         side = "resistance";
-        infantry[] = {"MNP_Rev_Soldier_F", "MNP_Rev_Soldier_F", "MNP_Rev_Soldier_F", "MNP_Rev_Soldier_AR", "MNP_Rev_Soldier_O", "MNP_Rev_Soldier_MG", "MNP_Rev_Soldier_M", "MNP_Rev_Soldier_AR", "MNP_Rev_Soldier_AT"};
+        infantry[] = {"MNP_Rev_Soldier_O", "MNP_Rev_Soldier_AR", "MNP_Rev_Soldier_F", "MNP_Rev_Soldier_AT", "MNP_Rev_Soldier_MG", "MNP_Rev_Soldier_AR", "MNP_Rev_Soldier_AT", "MNP_Rev_Soldier_AR", "MNP_Rev_Soldier_AT"};
         crewmen[] = {"MNP_Rev_Soldier_F", "MNP_Rev_Soldier_O"};
         technicals[] = {"B_G_Offroad_01_armed_F"};
         armour[] = {"B_G_Offroad_01_armed_F"};
@@ -337,7 +337,7 @@ class UnitTemplates {
 
     class MNP_IRE_WD {
         side = "resistance";
-        infantry[] = {"MNP_Irish_Soldier_F", "MNP_Irish_Soldier_F", "MNP_Irish_Soldier_F", "MNP_Irish_Soldier_AR", "MNP_Irish_Soldier_S", "MNP_Irish_Soldier_MG", "MNP_Irish_Soldier_Medic", "MNP_Irish_Soldier_AR", "MNP_Irish_Soldier_RAT"};
+        infantry[] = {"MNP_Irish_Soldier_S", "MNP_Irish_Soldier_AR", "MNP_Irish_Soldier_F", "MNP_Irish_Soldier_RAT", "MNP_Irish_Soldier_MG", "MNP_Irish_Soldier_AR", "MNP_Irish_Soldier_RAT", "MNP_Irish_Soldier_AR", "MNP_Irish_Soldier_RAT"};
         crewmen[] = {"MNP_Irish_Soldier_F", "MNP_Irish_Soldier_S"};
         technicals[] = {"I_MRAP_03_hmg_F"};
         armour[] = {"I_APC_tracked_03_cannon_F", "I_MBT_03_cannon_F"};
@@ -345,7 +345,7 @@ class UnitTemplates {
 
     class MNP_IRE_DE {
         side = "resistance";
-        infantry[] = {"MNP_Irish_Soldier_D", "MNP_Irish_Soldier_D", "MNP_Irish_Soldier_D", "MNP_Irish_Soldier_DAR", "MNP_Irish_Soldier_DS", "MNP_Irish_Soldier_DMG", "MNP_Irish_Soldier_DMedic", "MNP_Irish_Soldier_DAR", "MNP_Irish_Soldier_DRAT"};
+        infantry[] = {"MNP_Irish_Soldier_DS", "MNP_Irish_Soldier_DAR", "MNP_Irish_Soldier_D", "MNP_Irish_Soldier_DRAT", "MNP_Irish_Soldier_DMG", "MNP_Irish_Soldier_DAR", "MNP_Irish_Soldier_DRAT", "MNP_Irish_Soldier_DAR", "MNP_Irish_Soldier_DRAT"};
         crewmen[] = {"MNP_Irish_Soldier_D", "MNP_Irish_Soldier_DS"};
         technicals[] = {"I_MRAP_03_hmg_F"};
         armour[] = {"I_APC_tracked_03_cannon_F", "I_MBT_03_cannon_F"};
@@ -353,7 +353,7 @@ class UnitTemplates {
 
     class MNP_NZ {
         side = "resistance";
-        infantry[] = {"MNP_NZ_Soldier_F", "MNP_NZ_Soldier_F", "MNP_NZ_Soldier_F", "MNP_NZ_Soldier_AR", "MNP_NZ_Soldier_O", "MNP_NZ_Soldier_MG", "MNP_NZ_Soldier_Md", "MNP_NZ_Soldier_AR", "MNP_NZ_Soldier_AT"};
+        infantry[] = {"MNP_NZ_Soldier_O", "MNP_NZ_Soldier_AR", "MNP_NZ_Soldier_F", "MNP_NZ_Soldier_AT", "MNP_NZ_Soldier_MG", "MNP_NZ_Soldier_AR", "MNP_NZ_Soldier_AT", "MNP_NZ_Soldier_AR", "MNP_NZ_Soldier_AT"};
         crewmen[] = {"MNP_NZ_Soldier_F", "MNP_NZ_Soldier_O"};
         technicals[] = {"I_MRAP_03_hmg_F"};
         armour[] = {"I_APC_tracked_03_cannon_F", "I_MBT_03_cannon_F"};
@@ -361,7 +361,7 @@ class UnitTemplates {
 
     class MNP_FIN_WD {
         side = "resistance";
-        infantry[] = {"MNP_FIN_Soldier_F", "MNP_FIN_Soldier_F", "MNP_FIN_Soldier_F", "MNP_FIN_Soldier_AR", "MNP_FIN_Soldier_O", "MNP_FIN_Soldier_MG", "MNP_FIN_Soldier_MD", "MNP_FIN_Soldier_AR", "MNP_FIN_Soldier_AT"};
+        infantry[] = {"MNP_FIN_Soldier_O", "MNP_FIN_Soldier_AR", "MNP_FIN_Soldier_F", "MNP_FIN_Soldier_AT", "MNP_FIN_Soldier_MG", "MNP_FIN_Soldier_AR", "MNP_FIN_Soldier_AT", "MNP_FIN_Soldier_AR", "MNP_FIN_Soldier_AT"};
         crewmen[] = {"MNP_FIN_Soldier_F", "MNP_FIN_Soldier_O"};
         technicals[] = {"I_MRAP_03_hmg_F"};
         armour[] = {"I_APC_tracked_03_cannon_F", "I_MBT_03_cannon_F"};
@@ -369,7 +369,7 @@ class UnitTemplates {
 
     class MNP_FIN_SN {
         side = "resistance";
-        infantry[] = {"MNP_AFIN_Soldier_F", "MNP_AFIN_Soldier_F", "MNP_AFIN_Soldier_F", "MNP_AFIN_Soldier_AR", "MNP_AFIN_Soldier_O", "MNP_AFIN_Soldier_MG", "MNP_AFIN_Soldier_MD", "MNP_AFIN_Soldier_AR", "MNP_AFIN_Soldier_AT"};
+        infantry[] = {"MNP_AFIN_Soldier_O", "MNP_AFIN_Soldier_AR", "MNP_AFIN_Soldier_F", "MNP_AFIN_Soldier_AT", "MNP_AFIN_Soldier_MG", "MNP_AFIN_Soldier_AR", "MNP_AFIN_Soldier_AT", "MNP_AFIN_Soldier_AR", "MNP_AFIN_Soldier_AT"};
         crewmen[] = {"MNP_AFIN_Soldier_F", "MNP_AFIN_Soldier_O"};
         technicals[] = {"I_MRAP_03_hmg_F"};
         armour[] = {"I_APC_tracked_03_cannon_F", "I_MBT_03_cannon_F"};
@@ -377,7 +377,7 @@ class UnitTemplates {
 
     class MNP_NOR_WD {
         side = "resistance";
-        infantry[] = {"MNP_NOR_Soldier_F", "MNP_NOR_Soldier_F", "MNP_NOR_Soldier_F", "MNP_NOR_Soldier_AR", "MNP_NOR_Soldier_O", "MNP_NOR_Soldier_MG", "MNP_NOR_Soldier_Md", "MNP_NOR_Soldier_AR", "MNP_NOR_Soldier_AT"};
+        infantry[] = {"MNP_NOR_Soldier_O", "MNP_NOR_Soldier_AR", "MNP_NOR_Soldier_F", "MNP_NOR_Soldier_AT", "MNP_NOR_Soldier_MG", "MNP_NOR_Soldier_AR", "MNP_NOR_Soldier_AT", "MNP_NOR_Soldier_AR", "MNP_NOR_Soldier_AT"};
         crewmen[] = {"MNP_NOR_Soldier_F", "MNP_NOR_Soldier_O"};
         technicals[] = {"I_MRAP_03_hmg_F"};
         armour[] = {"I_APC_tracked_03_cannon_F", "I_MBT_03_cannon_F"};
@@ -385,7 +385,7 @@ class UnitTemplates {
 
     class MNP_NOR_DE {
         side = "resistance";
-        infantry[] = {"MNP_NOR_D_Soldier_F", "MNP_NOR_D_Soldier_F", "MNP_NOR_D_Soldier_F", "MNP_NOR_D_Soldier_AR", "MNP_NOR_D_Soldier_O", "MNP_NOR_D_Soldier_MG", "MNP_NOR_D_Soldier_Md", "MNP_NOR_D_Soldier_AR", "MNP_NOR_D_Soldier_AT"};
+        infantry[] = {"MNP_NOR_D_Soldier_O", "MNP_NOR_D_Soldier_AR", "MNP_NOR_D_Soldier_F", "MNP_NOR_D_Soldier_AT", "MNP_NOR_D_Soldier_MG", "MNP_NOR_D_Soldier_AR", "MNP_NOR_D_Soldier_AT", "MNP_NOR_D_Soldier_AR", "MNP_NOR_D_Soldier_AT"};
         crewmen[] = {"MNP_NOR_D_Soldier_F", "MNP_NOR_D_Soldier_O"};
         technicals[] = {"I_MRAP_03_hmg_F"};
         armour[] = {"I_APC_tracked_03_cannon_F", "I_MBT_03_cannon_F"};
@@ -393,7 +393,7 @@ class UnitTemplates {
 
     class AAF_GUER {
         side = "resistance";
-        infantry[] = {"I_G_Soldier_F", "I_G_Soldier_lite_F", "I_G_Soldier_F", "I_G_Soldier_TL_F", "I_G_Soldier_lite_F", "I_G_Soldier_SL_F", "I_G_soldier_AR_F", "I_G_soldier_LAT_F"};
+        infantry[] = {"I_G_Soldier_TL_F", "I_G_soldier_AR_F", "I_G_Soldier_lite_F", "I_G_soldier_LAT_F", "I_G_soldier_M_F", "I_G_soldier_AR_F", "I_G_soldier_LAT_F", "I_G_soldier_AR_F", "I_G_soldier_LAT_F"};
         crewmen[] = {"I_G_Soldier_lite_F", "I_G_engineer_F"};
         technicals[] = {"I_G_Offroad_01_armed_F"};
         armour[] = {"I_G_Offroad_01_armed_F"};

--- a/admiral/unit_templates.h
+++ b/admiral/unit_templates.h
@@ -41,7 +41,7 @@ class UnitTemplates {
 
     class MNP_US_RAN {
         side = "west";
-        infantry[] = {"MNP_USR_Soldier_O", "MNP_USR_Soldier_AR", "MNP_USR_Soldier_F", "MNP_USR_Soldier_AT", "MMG", "MNP_USR_Soldier_AR", "MNP_USR_Soldier_AT", "MNP_USR_Soldier_AR", "MNP_USR_Soldier_AT"};
+        infantry[] = {"MNP_USR_Soldier_O", "MNP_USR_Soldier_AR", "MNP_USR_Soldier_F", "MNP_USR_Soldier_AT", "MNP_USR_Soldier_MG", "MNP_USR_Soldier_AR", "MNP_USR_Soldier_AT", "MNP_USR_Soldier_AR", "MNP_USR_Soldier_AT"};
         crewmen[] = {"MNP_USR_Soldier_F", "MNP_USR_Soldier_O"};
         technicals[] = {"B_MRAP_01_hmg_F"};
         armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
@@ -137,7 +137,7 @@ class UnitTemplates {
 
     class CSAT_WOODLAND {
         side = "east";
-        infantry[] = {"O_Soldier_F", "O_Soldier_lite_F", "O_Soldier_F", "O_Soldier_AR_F", "O_Soldier_TL_F", "O_support_MG_F", "O_medic_F", "O_Soldier_AR_F", "O_Soldier_LAT_F"};
+        infantry[] = {"O_Soldier_TL_F", "O_Soldier_AR_F", "O_Soldier_lite_F", "O_Soldier_LAT_F", "O_support_MG_F", "O_Soldier_AR_F", "O_Soldier_LAT_F", "O_Soldier_AR_F", "O_Soldier_LAT_F"};
         crewmen[] = {"O_crew_F", "O_engineer_F"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -145,7 +145,7 @@ class UnitTemplates {
 
     class CSAT_URBAN {
         side = "east";
-        infantry[] = {"O_soldierU_F", "O_soldierU_AAR_F", "O_soldierU_F", "O_soldierU_AR_F", "O_soldierU_TL_F", "O_SoldierU_GL_F", "O_soldierU_medic_F", "O_soldierU_AR_F", "O_soldierU_LAT_F"};
+        infantry[] = {"O_soldierU_TL_F", "O_soldierU_AR_F", "O_soldierU_F", "O_soldierU_LAT_F", "O_soldierU_M_F", "O_soldierU_AR_F", "O_soldierU_LAT_F", "O_soldierU_AR_F", "O_soldierU_LAT_F"};
         crewmen[] = {"O_soldierU_F", "O_engineer_U_F"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -153,7 +153,7 @@ class UnitTemplates {
 
     class MNP_OPF_F_SN {
         side = "east";
-        infantry[] = {"MNP_RU_Soldier_Arctic_F", "MNP_RU_Soldier_Arctic_F", "MNP_RU_Soldier_Arctic_F", "MNP_RU_Soldier_Arctic_AR", "MNP_RU_Soldier_Arctic_O", "MNP_RU_Soldier_Arctic_MG", "MNP_RU_Soldier_Arctic_M", "MNP_RU_Soldier_Arctic_AR", "MNP_RU_Soldier_Arctic_AT"};
+        infantry[] = {"MNP_RU_Soldier_Arctic_O", "MNP_RU_Soldier_Arctic_AR", "MNP_RU_Soldier_Arctic_F", "MNP_RU_Soldier_Arctic_AT", "MNP_RU_Soldier_Arctic_MG", "MNP_RU_Soldier_Arctic_AR", "MNP_RU_Soldier_Arctic_AT", "MNP_RU_Soldier_Arctic_AR", "MNP_RU_Soldier_Arctic_AT"};
         crewmen[] = {"MNP_RU_Soldier_Arctic_F", "MNP_RU_Soldier_Arctic_O"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -161,7 +161,7 @@ class UnitTemplates {
 
     class MNP_CH_WD {
         side = "east";
-        infantry[] = {"MNP_CN_Soldier_F", "MNP_CN_Soldier_F", "MNP_CN_Soldier_F", "MNP_CN_Soldier_AR", "MNP_CN_Soldier_O", "MNP_CN_Soldier_MG", "MNP_CN_Soldier_MED", "MNP_CN_Soldier_AR", "MNP_CN_Soldier_RAT"};
+        infantry[] = {"MNP_CN_Soldier_O", "MNP_CN_Soldier_AR", "MNP_CN_Soldier_F", "MNP_CN_Soldier_RAT", "MNP_CN_Soldier_MG", "MNP_CN_Soldier_AR", "MNP_CN_Soldier_RAT", "MNP_CN_Soldier_AR", "MNP_CN_Soldier_RAT"};
         crewmen[] = {"MNP_CN_Soldier_F", "MNP_CN_Soldier_O"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -169,7 +169,7 @@ class UnitTemplates {
 
     class MNP_CH_DE {
         side = "east";
-        infantry[] = {"MNP_CD_Soldier_F", "MNP_CD_Soldier_F", "MNP_CD_Soldier_F", "MNP_CD_Soldier_AR", "MNP_CD_Soldier_O", "MNP_CD_Soldier_MG", "MNP_CD_Soldier_MED", "MNP_CD_Soldier_AR", "MNP_CD_Soldier_RAT"};
+        infantry[] = {"MNP_CD_Soldier_O", "MNP_CD_Soldier_AR", "MNP_CD_Soldier_F", "MNP_CD_Soldier_RAT", "MNP_CD_Soldier_MG", "MNP_CD_Soldier_AR", "MNP_CD_Soldier_RAT", "MNP_CD_Soldier_AR", "MNP_CD_Soldier_RAT"};
         crewmen[] = {"MNP_CD_Soldier_F", "MNP_CD_Soldier_O"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -177,7 +177,7 @@ class UnitTemplates {
 
     class MNP_CH_MAR {
         side = "east";
-        infantry[] = {"MNP_CM_Soldier_F", "MNP_CM_Soldier_F", "MNP_CM_Soldier_F", "MNP_CM_Soldier_AR", "MNP_CM_Soldier_O", "MNP_CM_Soldier_MG", "MNP_CM_Soldier_MED", "MNP_CM_Soldier_AR", "MNP_CM_Soldier_RAT"};
+        infantry[] = {"MNP_CM_Soldier_O", "MNP_CM_Soldier_AR", "MNP_CM_Soldier_F", "MNP_CM_Soldier_RAT", "MNP_CM_Soldier_MG", "MNP_CM_Soldier_AR", "MNP_CM_Soldier_RAT", "MNP_CM_Soldier_AR", "MNP_CM_Soldier_RAT"};
         crewmen[] = {"MNP_CM_Soldier_F", "MNP_CM_Soldier_O"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -185,7 +185,7 @@ class UnitTemplates {
 
     class MNP_CH_HWD {
         side = "east";
-        infantry[] = {"MNP_CN_Soldier_heavy_F", "MNP_CN_Soldier_heavy_F", "MNP_CN_Soldier_heavy_F", "MNP_CN_Soldier_Heavy_AR", "MNP_CN_Soldier_heavy_O", "MNP_CN_Soldier_Heavy_MG", "MNP_CN_Soldier_Heavy_MED", "MNP_CN_Soldier_Heavy_AR", "MNP_CN_Soldier_Heavy_AT"};
+        infantry[] = {"MNP_CN_Soldier_heavy_O", "MNP_CN_Soldier_Heavy_AR", "MNP_CN_Soldier_heavy_F", "MNP_CN_Soldier_Heavy_AT", "MNP_CN_Soldier_Heavy_MG", "MNP_CN_Soldier_Heavy_AR", "MNP_CN_Soldier_Heavy_AT", "MNP_CN_Soldier_Heavy_AR", "MNP_CN_Soldier_Heavy_AT"};
         crewmen[] = {"MNP_CN_Soldier_heavy_F", "MNP_CN_Soldier_heavy_O"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -193,7 +193,7 @@ class UnitTemplates {
 
     class MNP_CH_HDE {
         side = "east";
-        infantry[] = {"MNP_CN_Soldier_heavy_D", "MNP_CN_Soldier_heavy_D", "MNP_CN_Soldier_heavy_D", "MNP_CN_Soldier_Heavy_DAR", "MNP_CN_Soldier_heavy_DO", "MNP_CN_Soldier_Heavy_DMG", "MNP_CN_Soldier_Heavy_DMED", "MNP_CN_Soldier_Heavy_DAR", "MNP_CN_Soldier_Heavy_DAT"};
+        infantry[] = {"MNP_CN_Soldier_heavy_DO", "MNP_CN_Soldier_Heavy_DAR", "MNP_CN_Soldier_heavy_D", "MNP_CN_Soldier_Heavy_DAT", "MNP_CN_Soldier_Heavy_DMG", "MNP_CN_Soldier_Heavy_DAR", "MNP_CN_Soldier_Heavy_DAT", "MNP_CN_Soldier_Heavy_DAR", "MNP_CN_Soldier_Heavy_DAT"};
         crewmen[] = {"MNP_CN_Soldier_heavy_D", "MNP_CN_Soldier_heavy_DO"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -201,7 +201,7 @@ class UnitTemplates {
 
     class MNP_RU_VDV_WD {
         side = "east";
-        infantry[] = {"MNP_RU_Soldier_MEDIUM", "MNP_RU_Soldier_MEDIUM", "MNP_RU_Soldier_MEDIUM", "MNP_RU_Soldier_AR", "MNP_RU_Soldier_O", "MNP_RU_Soldier_MG", "MNP_RU_Soldier_M", "MNP_RU_Soldier_AR", "MNP_RU_Soldier_AT"};
+        infantry[] = {"MNP_RU_Soldier_O", "MNP_RU_Soldier_AR", "MNP_RU_Soldier_MEDIUM", "MNP_RU_Soldier_AT", "MNP_RU_Soldier_MG", "MNP_RU_Soldier_AR", "MNP_RU_Soldier_AT", "MNP_RU_Soldier_AR", "MNP_RU_Soldier_AT"};
         crewmen[] = {"MNP_RU_Soldier_MEDIUM", "MNP_RU_Soldier_O"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -209,7 +209,7 @@ class UnitTemplates {
 
     class MNP_RU_VDV_DE {
         side = "east";
-        infantry[] = {"MNP_RU_Soldier_MEDIUM_D", "MNP_RU_Soldier_MEDIUM_D", "MNP_RU_Soldier_MEDIUM_D", "MNP_RU_Soldier_AR_D", "MNP_RU_Soldier_O_D", "MNP_RU_Soldier_MG_D", "MNP_RU_Soldier_M_D", "MNP_RU_Soldier_AR_D", "MNP_RU_Soldier_AT_D"};
+        infantry[] = {"MNP_RU_Soldier_O_D", "MNP_RU_Soldier_AR_D", "MNP_RU_Soldier_MEDIUM_D", "MNP_RU_Soldier_AT_D", "MNP_RU_Soldier_MG_D", "MNP_RU_Soldier_AR_D", "MNP_RU_Soldier_AT_D", "MNP_RU_Soldier_AR_D", "MNP_RU_Soldier_AT_D"};
         crewmen[] = {"MNP_RU_Soldier_MEDIUM_D", "MNP_RU_Soldier_O_D"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -217,7 +217,7 @@ class UnitTemplates {
 
     class MNP_RU_HWD {
         side = "east";
-        infantry[] = {"MNP_RU_Soldier_heavy_F", "MNP_RU_Soldier_heavy_F", "MNP_RU_Soldier_heavy_F", "MNP_RU_Soldier_heavy_AR", "MNP_RU_Soldier_heavy_O", "MNP_RU_Soldier_heavy_MG", "MNP_RU_Soldier_heavy_M", "MNP_RU_Soldier_heavy_AR", "MNP_RU_Soldier_heavy_AT"};
+        infantry[] = {"MNP_RU_Soldier_heavy_O", "MNP_RU_Soldier_heavy_AR", "MNP_RU_Soldier_heavy_F", "MNP_RU_Soldier_heavy_AT", "MNP_RU_Soldier_heavy_MG", "MNP_RU_Soldier_heavy_AR", "MNP_RU_Soldier_heavy_AT", "MNP_RU_Soldier_heavy_AR", "MNP_RU_Soldier_heavy_AT"};
         crewmen[] = {"MNP_RU_Soldier_heavy_F", "MNP_RU_Soldier_heavy_O"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -225,7 +225,7 @@ class UnitTemplates {
 
     class MNP_RU_HDE {
         side = "east";
-        infantry[] = {"MNP_RU_Soldier_heavy_D", "MNP_RU_Soldier_heavy_D", "MNP_RU_Soldier_heavy_D", "MNP_RU_Soldier_heavy_DAR", "MNP_RU_Soldier_heavy_DO", "MNP_RU_Soldier_heavy_DMG", "MNP_RU_Soldier_heavy_DM", "MNP_RU_Soldier_heavy_DAR", "MNP_RU_Soldier_heavy_DAT"};
+        infantry[] = {"MNP_RU_Soldier_heavy_DO", "MNP_RU_Soldier_heavy_DAR", "MNP_RU_Soldier_heavy_D", "MNP_RU_Soldier_heavy_DAT", "MNP_RU_Soldier_heavy_DMG", "MNP_RU_Soldier_heavy_DAR", "MNP_RU_Soldier_heavy_DAT", "MNP_RU_Soldier_heavy_DAR", "MNP_RU_Soldier_heavy_DAT"};
         crewmen[] = {"MNP_RU_Soldier_heavy_D", "MNP_RU_Soldier_heavy_DO"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -233,7 +233,7 @@ class UnitTemplates {
 
     class MNP_KOR_OD {
         side = "east";
-        infantry[] = {"MNP_NK_Soldier_F", "MNP_NK_Soldier_F", "MNP_NK_Soldier_F", "MNP_NK_Soldier_AR", "MNP_NK_Soldier_O", "MNP_NK_Soldier_MG", "MNP_NK_Soldier_MD", "MNP_NK_Soldier_AR", "MNP_NK_Soldier_AT"};
+        infantry[] = {"MNP_NK_Soldier_O", "MNP_NK_Soldier_AR", "MNP_NK_Soldier_F", "MNP_NK_Soldier_AT", "MNP_NK_Soldier_MG", "MNP_NK_Soldier_AR", "MNP_NK_Soldier_AT", "MNP_NK_Soldier_AR", "MNP_NK_Soldier_AT"};
         crewmen[] = {"MNP_NK_Soldier_F", "MNP_NK_Soldier_O"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -241,7 +241,7 @@ class UnitTemplates {
 
     class MNP_KOR_WD {
         side = "east";
-        infantry[] = {"MNP_NKC_Soldier_F", "MNP_NKC_Soldier_F", "MNP_NKC_Soldier_F", "MNP_NKC_Soldier_AR", "MNP_NKC_Soldier_O", "MNP_NKC_Soldier_MG", "MNP_NKC_Soldier_MD", "MNP_NKC_Soldier_AR", "MNP_NKC_Soldier_AT"};
+        infantry[] = {"MNP_NKC_Soldier_O", "MNP_NKC_Soldier_AR", "MNP_NKC_Soldier_F", "MNP_NKC_Soldier_AT", "MNP_NKC_Soldier_MG", "MNP_NKC_Soldier_AR", "MNP_NKC_Soldier_AT", "MNP_NKC_Soldier_AR", "MNP_NKC_Soldier_AT"};
         crewmen[] = {"MNP_NKC_Soldier_F", "MNP_NKC_Soldier_O"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -249,7 +249,7 @@ class UnitTemplates {
 
     class MNP_RU_WD {
         side = "east";
-        infantry[] = {"MNP_RO_Soldier_F", "MNP_RO_Soldier_F", "MNP_RO_Soldier_F", "MNP_RO_Soldier_AR", "MNP_RO_Soldier_O", "MNP_RO_Soldier_MG", "MNP_RO_Soldier_M", "MNP_RO_Soldier_AR", "MNP_RO_Soldier_AT"};
+        infantry[] = {"MNP_RO_Soldier_O", "MNP_RO_Soldier_AR", "MNP_RO_Soldier_F", "MNP_RO_Soldier_AT", "MNP_RO_Soldier_MG", "MNP_RO_Soldier_AR", "MNP_RO_Soldier_AT", "MNP_RO_Soldier_AR", "MNP_RO_Soldier_AT"};
         crewmen[] = {"MNP_RO_Soldier_F", "MNP_RO_Soldier_O"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -257,7 +257,7 @@ class UnitTemplates {
 
     class MNP_RU_TTK {
         side = "east";
-        infantry[] = {"MNP_RO2_Soldier_F", "MNP_RO2_Soldier_F", "MNP_RO2_Soldier_F", "MNP_RO2_Soldier_AR", "MNP_RO2_Soldier_O", "MNP_RO2_Soldier_MG", "MNP_RO2_Soldier_M", "MNP_RO2_Soldier_AR", "MNP_RO2_Soldier_AT"};
+        infantry[] = {"MNP_RO2_Soldier_O", "MNP_RO2_Soldier_AR", "MNP_RO2_Soldier_F", "MNP_RO2_Soldier_AT", "MNP_RO2_Soldier_MG", "MNP_RO2_Soldier_AR", "MNP_RO2_Soldier_AT", "MNP_RO2_Soldier_AR", "MNP_RO2_Soldier_AT"};
         crewmen[] = {"MNP_RO2_Soldier_F", "MNP_RO2_Soldier_O"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
@@ -265,7 +265,7 @@ class UnitTemplates {
 
     class MNP_RU_AIR {
         side = "east";
-        infantry[] = {"MNP_RO3_Soldier_F", "MNP_RO3_Soldier_F", "MNP_RO3_Soldier_F", "MNP_RO3_Soldier_AR", "MNP_RO3_Soldier_O", "MNP_RO3_Soldier_MG", "MNP_RO3_Soldier_M", "MNP_RO3_Soldier_AR", "MNP_RO3_Soldier_AT"};
+        infantry[] = {"MNP_RO3_Soldier_O", "MNP_RO3_Soldier_AR", "MNP_RO3_Soldier_F", "MNP_RO3_Soldier_AT", "MNP_RO3_Soldier_MG", "MNP_RO3_Soldier_AR", "MNP_RO3_Soldier_AT", "MNP_RO3_Soldier_AR", "MNP_RO3_Soldier_AT"};
         crewmen[] = {"MNP_RO3_Soldier_F", "MNP_RO3_Soldier_O"};
         technicals[] = {"O_MRAP_02_hmg_F"};
         armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};


### PR DESCRIPTION
Switched to the following format to increase the AT + ARs in EI fireteams and remove some stuff like medics who had no real impact on gameplay.

Using the following template: 
```c++
infantry[] = {"FTL", "AR", "AAR", "RAT", "MMG", "AR", "RAT", "AR", "RAT"};
```

Groups that didn't have MMGs got marksmen instead, not sure if wise yet. Might also be too many ARs, open to input on this.