### PR TITLE
Adding CUP Vehicles to Unit Templates

### DIFF
--- a/admiral/unit_templates.h
+++ b/admiral/unit_templates.h
@@ -19,56 +19,56 @@ class UnitTemplates {
         side = "west";
         infantry[] = {"MNP_USMC_Soldier_O", "MNP_USMC_Soldier_AR", "MNP_USMC_Soldier_F", "MNP_USMC_Soldier_AT", "MNP_USMC_Soldier_MG", "MNP_USMC_Soldier_DIAR", "MNP_USMC_Soldier_AT", "MNP_USMC_Soldier_DIAR", "MNP_USMC_Soldier_AT"};
         crewmen[] = {"MNP_USMC_Soldier_F", "MNP_USMC_Soldier_O"};
-        technicals[] = {"B_MRAP_01_hmg_F"};
-        armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
+        technicals[] = {"CUP_B_HMMWV_M1114_USMC","CUP_B_HMMWV_M1114_USMC","CUP_B_HMMWV_M2_USMC","CUP_B_HMMWV_M2_USMC","CUP_B_HMMWV_MK19_USMC"};
+        armour[] = {"CUP_B_LAV25_USMC", "CUP_B_LAV25_USMC","CUP_B_AAV_USMC","CUP_B_M1A1_Woodland_USMC"};
     };
 
     class MNP_USMC_DE {
         side = "west";
         infantry[] = {"MNP_USMC_Soldier_DO", "MNP_USMC_Soldier_DAR", "MNP_USMC_Soldier_DF", "MNP_USMC_Soldier_DAT", "MNP_USMC_Soldier_DMG", "MNP_USMC_Soldier_DIAR", "MNP_USMC_Soldier_DAT", "MNP_USMC_Soldier_DIAR", "MNP_USMC_Soldier_DAT"};
         crewmen[] = {"MNP_USMC_Soldier_DF", "MNP_USMC_Soldier_DO"};
-        technicals[] = {"B_MRAP_01_hmg_F"};
-        armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
+        technicals[] = {"CUP_B_HMMWV_M2_GPK_USA","CUP_B_HMMWV_Crows_M2_USA","CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_MK19_USA"};
+        armour[] = {"CUP_B_LAV25_USMC", "CUP_B_LAV25_USMC","CUP_B_AAV_USMC","CUP_B_M1A1_DES_US_Army"};
     };
 
     class MNP_USMC_SN {
         side = "west";
         infantry[] = {"MNP_USMCA_Soldier_O", "MNP_USMCA_Soldier_AR", "MNP_USMCA_Soldier_F", "MNP_USMCA_Soldier_AT", "MNP_USMCA_Soldier_MG", "MNP_USMC_Soldier_DIAR", "MNP_USMCA_Soldier_AT", "MNP_USMC_Soldier_DIAR", "MNP_USMCA_Soldier_AT"};
         crewmen[] = {"MNP_USMCA_Soldier_F", "MNP_USMCA_Soldier_O"};
-        technicals[] = {"B_MRAP_01_hmg_F"};
-        armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
+        technicals[] = {"CUP_B_HMMWV_M1114_USMC","CUP_B_HMMWV_M1114_USMC","CUP_B_HMMWV_M1114_USMC","CUP_B_HMMWV_M2_USMC","CUP_B_HMMWV_MK19_USMC"};
+        armour[] = {"CUP_B_LAV25_USMC", "CUP_B_LAV25_USMC","CUP_B_AAV_USMC","CUP_B_M1A1_Woodland_USMC"};
     };
 
     class MNP_US_RAN {
         side = "west";
         infantry[] = {"MNP_USR_Soldier_O", "MNP_USR_Soldier_AR", "MNP_USR_Soldier_F", "MNP_USR_Soldier_AT", "MNP_USR_Soldier_MG", "MNP_USR_Soldier_AR", "MNP_USR_Soldier_AT", "MNP_USR_Soldier_AR", "MNP_USR_Soldier_AT"};
         crewmen[] = {"MNP_USR_Soldier_F", "MNP_USR_Soldier_O"};
-        technicals[] = {"B_MRAP_01_hmg_F"};
-        armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
+        technicals[] = {"CUP_B_HMMWV_M2_GPK_USA","CUP_B_HMMWV_M2_GPK_USA","CUP_B_HMMWV_Crows_MK19_USA","CUP_B_HMMWV_SOV_USA"};
+        armour[] = {"B_APC_Wheeled_01_cannon_F", "CUP_B_M1A2_TUSK_MG_DES_US_Army"};
     };
 
     class MNP_US_ACU {
         side = "west";
         infantry[] = {"MNP_USA_Soldier_O", "MNP_USA_Soldier_AR", "MNP_USA_Soldier_F", "MNP_USA_Soldier_AT", "MNP_USA_Soldier_MG", "MNP_USA_Soldier_AR", "MNP_USA_Soldier_AT", "MNP_USA_Soldier_AR", "MNP_USA_Soldier_AT"};
         crewmen[] = {"MNP_USA_Soldier_F", "MNP_USA_Soldier_O"};
-        technicals[] = {"B_MRAP_01_hmg_F"};
-        armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
+        technicals[] = {"CUP_B_HMMWV_M2_GPK_USA","CUP_B_HMMWV_Crows_M2_USA","CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_MK19_USA"};
+        armour[] = {"CUP_B_M113_USA", "CUP_B_M113_USA","CUP_B_M163_USA","CUP_B_M1A1_DES_US_Army"};
     };
 
     class MNP_US_WD {
         side = "west";
         infantry[] = {"MNP_Wood_Soldier_O", "MNP_M81_Soldier_AR", "MNP_Wood_Soldier_F", "MNP_M81_Soldier_AT", "MNP_M81_Soldier_MG", "MNP_M81_Soldier_AR", "MNP_M81_Soldier_AT", "MNP_M81_Soldier_AR", "MNP_M81_Soldier_AT"};
         crewmen[] = {"MNP_M81_Soldier_F", "MNP_M81_Soldier_O"};
-        technicals[] = {"B_MRAP_01_hmg_F"};
-        armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
+        technicals[] = {"CUP_B_HMMWV_M1114_USMC","CUP_B_HMMWV_M1114_USMC","CUP_B_HMMWV_M2_USMC","CUP_B_HMMWV_M2_USMC","CUP_B_HMMWV_MK19_USMC"};
+        armour[] = {"CUP_B_M113_USA", "CUP_B_M113_USA","CUP_B_M163_USA","CUP_B_M1A1_Woodland_US_Army"};
     };
 
     class MNP_US_DE {
         side = "west";
         infantry[] = {"MNP_3Co_Soldier_O2", "MNP_3Co_Soldier_AR", "MNP_3Co_Soldier_F2", "MNP_3Co_Soldier_AT", "MNP_3Co_Soldier_MG", "MNP_3Co_Soldier_AR", "MNP_3Co_Soldier_AT", "MNP_3Co_Soldier_AR", "MNP_3Co_Soldier_AT"};
         crewmen[] = {"MNP_3Co_Soldier_F", "MNP_3Co_Soldier_O"};
-        technicals[] = {"B_MRAP_01_hmg_F"};
-        armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
+        technicals[] = {"CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_MK19_USA"};
+        armour[] = {"CUP_B_M113_USA", "CUP_B_M113_USA","CUP_B_M163_USA","CUP_B_M1A1_DES_US_Army"};
     };
 
     class MNP_GE_WD {
@@ -91,40 +91,40 @@ class UnitTemplates {
         side = "west";
         infantry[] = {"MNP_Canada_Soldier_S", "MNP_Canada_Soldier_AR", "MNP_Canada_Soldier_F", "MNP_Canada_Soldier_AT", "MNP_Canada_Soldier_MG", "MNP_Canada_Soldier_AR", "MNP_Canada_Soldier_AT", "MNP_Canada_Soldier_AR", "MNP_Canada_Soldier_AT"};
         crewmen[] = {"MNP_Canada_Soldier_F", "MNP_Canada_Soldier_S"};
-        technicals[] = {"B_MRAP_01_hmg_F"};
-        armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
+        technicals[] = {"CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_MK19_USA"};
+        armour[] = {"CUP_B_M113_USA", "CUP_B_M113_USA","CUP_B_LAV25_USMC","CUP_B_LAV25_USMC"};
     };
 
     class MNP_CA_DE {
         side = "west";
         infantry[] = {"MNP_Canada_Soldier_DS", "MNP_Canada_Soldier_DAR", "MNP_Canada_Soldier_DF", "MNP_Canada_Soldier_DAT", "MNP_Canada_Soldier_DMG", "MNP_Canada_Soldier_DAR", "MNP_Canada_Soldier_DAT", "MNP_Canada_Soldier_DAR", "MNP_Canada_Soldier_DAT"};
         crewmen[] = {"MNP_Canada_Soldier_DF", "MNP_Canada_Soldier_DS"};
-        technicals[] = {"B_MRAP_01_hmg_F"};
-        armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
+        technicals[] = {"CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_MK19_USA"};
+        armour[] = {"CUP_B_M113_USA", "CUP_B_M113_USA","CUP_B_LAV25_USMC","CUP_B_LAV25_USMC"};
     };
 
     class MNP_AUS {
         side = "west";
         infantry[] = {"MNP_AUS_Soldier_S", "MNP_AUS_Soldier_AR", "MNP_AUS_Soldier_F", "MNP_AUS_Soldier_AT", "MNP_AUS_Soldier_MG", "MNP_AUS_Soldier_AR", "MNP_AUS_Soldier_AT", "MNP_AUS_Soldier_AR", "MNP_AUS_Soldier_AT"};
         crewmen[] = {"MNP_AUS_Soldier_F", "MNP_AUS_Soldier_S"};
-        technicals[] = {"B_MRAP_01_hmg_F"};
-        armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
+        technicals[] = {"CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_MK19_USA"};
+        armour[] = {"CUP_B_M113_USA", "CUP_B_M113_USA","CUP_B_LAV25_USMC","CUP_B_LAV25_USMC"};
     };
 
     class MNP_ROK {
         side = "west";
         infantry[] = {"MNP_ROK_Soldier_O", "MNP_ROK_Soldier_AR", "MNP_ROK_Soldier_F", "MNP_ROK_Soldier_AT", "MNP_ROK_Soldier_MG", "MNP_ROK_Soldier_AR", "MNP_ROK_Soldier_AT", "MNP_ROK_Soldier_AR", "MNP_ROK_Soldier_AT"};
         crewmen[] = {"MNP_ROK_Soldier_F", "MNP_ROK_Soldier_O"};
-        technicals[] = {"B_MRAP_01_hmg_F"};
-        armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
+        technicals[] = {"CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_MK19_USA"};
+        armour[] = {"CUP_B_M113_USA", "CUP_B_M113_USA","CUP_B_M163_USA"};
     };
 
     class MNP_PMC {
         side = "west";
         infantry[] = {"MNP_OD_Soldier_O", "MNP_OD_Soldier_AR", "MNP_OD_Soldier_F", "MNP_OD_Soldier_AT", "MNP_OD_Soldier_MG", "MNP_OD_Soldier_AR", "MNP_OD_Soldier_AT", "MNP_OD_Soldier_AR", "MNP_OD_Soldier_AT"};
         crewmen[] = {"MNP_OD_Soldier_F", "MNP_OD_Soldier_O"};
-        technicals[] = {"B_MRAP_01_hmg_F"};
-        armour[] = {"B_APC_Wheeled_01_cannon_F", "B_MBT_01_TUSK_F"};
+        technicals[] = {"CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_M2_USA","CUP_B_HMMWV_MK19_USA"};
+        armour[] = {"CUP_B_M113_USA", "CUP_B_M113_USA","CUP_B_LAV25_USMC","CUP_B_LAV25_USMC"};
     }; 
 
     class FIA_GUER {
@@ -163,112 +163,112 @@ class UnitTemplates {
         side = "east";
         infantry[] = {"MNP_CN_Soldier_O", "MNP_CN_Soldier_AR", "MNP_CN_Soldier_F", "MNP_CN_Soldier_RAT", "MNP_CN_Soldier_MG", "MNP_CN_Soldier_AR", "MNP_CN_Soldier_RAT", "MNP_CN_Soldier_AR", "MNP_CN_Soldier_RAT"};
         crewmen[] = {"MNP_CN_Soldier_F", "MNP_CN_Soldier_O"};
-        technicals[] = {"O_MRAP_02_hmg_F"};
-        armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
+        technicals[] = {"CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_RU"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_I_T55_TK_GUE","CUP_O_T72_SLA"};
     };
 
     class MNP_CH_DE {
         side = "east";
         infantry[] = {"MNP_CD_Soldier_O", "MNP_CD_Soldier_AR", "MNP_CD_Soldier_F", "MNP_CD_Soldier_RAT", "MNP_CD_Soldier_MG", "MNP_CD_Soldier_AR", "MNP_CD_Soldier_RAT", "MNP_CD_Soldier_AR", "MNP_CD_Soldier_RAT"};
         crewmen[] = {"MNP_CD_Soldier_F", "MNP_CD_Soldier_O"};
-        technicals[] = {"O_MRAP_02_hmg_F"};
-        armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
+        technicals[] = {"CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_RU"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_I_T55_TK_GUE","CUP_O_T72_SLA"};
     };
 
     class MNP_CH_MAR {
         side = "east";
         infantry[] = {"MNP_CM_Soldier_O", "MNP_CM_Soldier_AR", "MNP_CM_Soldier_F", "MNP_CM_Soldier_RAT", "MNP_CM_Soldier_MG", "MNP_CM_Soldier_AR", "MNP_CM_Soldier_RAT", "MNP_CM_Soldier_AR", "MNP_CM_Soldier_RAT"};
         crewmen[] = {"MNP_CM_Soldier_F", "MNP_CM_Soldier_O"};
-        technicals[] = {"O_MRAP_02_hmg_F"};
-        armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
+        technicals[] = {"CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_RU"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_I_T55_TK_GUE","CUP_O_T72_SLA"};
     };
 
     class MNP_CH_HWD {
         side = "east";
         infantry[] = {"MNP_CN_Soldier_heavy_O", "MNP_CN_Soldier_Heavy_AR", "MNP_CN_Soldier_heavy_F", "MNP_CN_Soldier_Heavy_AT", "MNP_CN_Soldier_Heavy_MG", "MNP_CN_Soldier_Heavy_AR", "MNP_CN_Soldier_Heavy_AT", "MNP_CN_Soldier_Heavy_AR", "MNP_CN_Soldier_Heavy_AT"};
         crewmen[] = {"MNP_CN_Soldier_heavy_F", "MNP_CN_Soldier_heavy_O"};
-        technicals[] = {"O_MRAP_02_hmg_F"};
-        armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
+        technicals[] = {"CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_RU"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_I_T55_TK_GUE","CUP_O_T72_SLA"};
     };
 
     class MNP_CH_HDE {
         side = "east";
         infantry[] = {"MNP_CN_Soldier_heavy_DO", "MNP_CN_Soldier_Heavy_DAR", "MNP_CN_Soldier_heavy_D", "MNP_CN_Soldier_Heavy_DAT", "MNP_CN_Soldier_Heavy_DMG", "MNP_CN_Soldier_Heavy_DAR", "MNP_CN_Soldier_Heavy_DAT", "MNP_CN_Soldier_Heavy_DAR", "MNP_CN_Soldier_Heavy_DAT"};
         crewmen[] = {"MNP_CN_Soldier_heavy_D", "MNP_CN_Soldier_heavy_DO"};
-        technicals[] = {"O_MRAP_02_hmg_F"};
-        armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
+        technicals[] = {"CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_RU"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_I_T55_TK_GUE","CUP_O_T72_SLA"};
     };
 
     class MNP_RU_VDV_WD {
         side = "east";
         infantry[] = {"MNP_RU_Soldier_O", "MNP_RU_Soldier_AR", "MNP_RU_Soldier_MEDIUM", "MNP_RU_Soldier_AT", "MNP_RU_Soldier_MG", "MNP_RU_Soldier_AR", "MNP_RU_Soldier_AT", "MNP_RU_Soldier_AR", "MNP_RU_Soldier_AT"};
         crewmen[] = {"MNP_RU_Soldier_MEDIUM", "MNP_RU_Soldier_O"};
-        technicals[] = {"O_MRAP_02_hmg_F"};
-        armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
+        technicals[] = {"CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_RU"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_O_BTR90_RU","CUP_O_T72_RU"};
     };
 
     class MNP_RU_VDV_DE {
         side = "east";
         infantry[] = {"MNP_RU_Soldier_O_D", "MNP_RU_Soldier_AR_D", "MNP_RU_Soldier_MEDIUM_D", "MNP_RU_Soldier_AT_D", "MNP_RU_Soldier_MG_D", "MNP_RU_Soldier_AR_D", "MNP_RU_Soldier_AT_D", "MNP_RU_Soldier_AR_D", "MNP_RU_Soldier_AT_D"};
         crewmen[] = {"MNP_RU_Soldier_MEDIUM_D", "MNP_RU_Soldier_O_D"};
-        technicals[] = {"O_MRAP_02_hmg_F"};
-        armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
+        technicals[] = {"CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_RU"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_O_BTR90_RU","CUP_O_T72_RU"};
     };
 
     class MNP_RU_HWD {
         side = "east";
         infantry[] = {"MNP_RU_Soldier_heavy_O", "MNP_RU_Soldier_heavy_AR", "MNP_RU_Soldier_heavy_F", "MNP_RU_Soldier_heavy_AT", "MNP_RU_Soldier_heavy_MG", "MNP_RU_Soldier_heavy_AR", "MNP_RU_Soldier_heavy_AT", "MNP_RU_Soldier_heavy_AR", "MNP_RU_Soldier_heavy_AT"};
         crewmen[] = {"MNP_RU_Soldier_heavy_F", "MNP_RU_Soldier_heavy_O"};
-        technicals[] = {"O_MRAP_02_hmg_F"};
-        armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
+        technicals[] = {"CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_RU"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_O_BTR90_RU","CUP_O_T72_RU"};
     };
 
     class MNP_RU_HDE {
         side = "east";
         infantry[] = {"MNP_RU_Soldier_heavy_DO", "MNP_RU_Soldier_heavy_DAR", "MNP_RU_Soldier_heavy_D", "MNP_RU_Soldier_heavy_DAT", "MNP_RU_Soldier_heavy_DMG", "MNP_RU_Soldier_heavy_DAR", "MNP_RU_Soldier_heavy_DAT", "MNP_RU_Soldier_heavy_DAR", "MNP_RU_Soldier_heavy_DAT"};
         crewmen[] = {"MNP_RU_Soldier_heavy_D", "MNP_RU_Soldier_heavy_DO"};
-        technicals[] = {"O_MRAP_02_hmg_F"};
-        armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
+        technicals[] = {"CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_RU"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_O_BTR90_RU","CUP_O_T72_RU"};
     };
 
     class MNP_KOR_OD {
         side = "east";
         infantry[] = {"MNP_NK_Soldier_O", "MNP_NK_Soldier_AR", "MNP_NK_Soldier_F", "MNP_NK_Soldier_AT", "MNP_NK_Soldier_MG", "MNP_NK_Soldier_AR", "MNP_NK_Soldier_AT", "MNP_NK_Soldier_AR", "MNP_NK_Soldier_AT"};
         crewmen[] = {"MNP_NK_Soldier_F", "MNP_NK_Soldier_O"};
-        technicals[] = {"O_MRAP_02_hmg_F"};
-        armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
+        technicals[] = {"CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_RU"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_I_T55_TK_GUE","CUP_O_T72_SLA"};
     };
 
     class MNP_KOR_WD {
         side = "east";
         infantry[] = {"MNP_NKC_Soldier_O", "MNP_NKC_Soldier_AR", "MNP_NKC_Soldier_F", "MNP_NKC_Soldier_AT", "MNP_NKC_Soldier_MG", "MNP_NKC_Soldier_AR", "MNP_NKC_Soldier_AT", "MNP_NKC_Soldier_AR", "MNP_NKC_Soldier_AT"};
         crewmen[] = {"MNP_NKC_Soldier_F", "MNP_NKC_Soldier_O"};
-        technicals[] = {"O_MRAP_02_hmg_F"};
-        armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
+        technicals[] = {"CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_RU"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_I_T55_TK_GUE","CUP_O_T72_SLA"};
     };
 
     class MNP_RU_WD {
         side = "east";
         infantry[] = {"MNP_RO_Soldier_O", "MNP_RO_Soldier_AR", "MNP_RO_Soldier_F", "MNP_RO_Soldier_AT", "MNP_RO_Soldier_MG", "MNP_RO_Soldier_AR", "MNP_RO_Soldier_AT", "MNP_RO_Soldier_AR", "MNP_RO_Soldier_AT"};
         crewmen[] = {"MNP_RO_Soldier_F", "MNP_RO_Soldier_O"};
-        technicals[] = {"O_MRAP_02_hmg_F"};
-        armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
+        technicals[] = {"CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_RU"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_I_T55_TK_GUE","CUP_O_T72_RU"};
     };
 
     class MNP_RU_TTK {
         side = "east";
         infantry[] = {"MNP_RO2_Soldier_O", "MNP_RO2_Soldier_AR", "MNP_RO2_Soldier_F", "MNP_RO2_Soldier_AT", "MNP_RO2_Soldier_MG", "MNP_RO2_Soldier_AR", "MNP_RO2_Soldier_AT", "MNP_RO2_Soldier_AR", "MNP_RO2_Soldier_AT"};
         crewmen[] = {"MNP_RO2_Soldier_F", "MNP_RO2_Soldier_O"};
-        technicals[] = {"O_MRAP_02_hmg_F"};
-        armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
+        technicals[] = {"CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_RU"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_I_T55_TK_GUE","CUP_O_T72_RU"};
     };
 
     class MNP_RU_AIR {
         side = "east";
         infantry[] = {"MNP_RO3_Soldier_O", "MNP_RO3_Soldier_AR", "MNP_RO3_Soldier_F", "MNP_RO3_Soldier_AT", "MNP_RO3_Soldier_MG", "MNP_RO3_Soldier_AR", "MNP_RO3_Soldier_AT", "MNP_RO3_Soldier_AR", "MNP_RO3_Soldier_AT"};
         crewmen[] = {"MNP_RO3_Soldier_F", "MNP_RO3_Soldier_O"};
-        technicals[] = {"O_MRAP_02_hmg_F"};
-        armour[] = {"O_APC_Tracked_02_cannon_F", "O_MBT_02_cannon_F"};
+        technicals[] = {"CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_RU"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_I_T55_TK_GUE","CUP_I_T55_TK_GUE"};
     };
 
     class AAF_WOODLAND {
@@ -291,40 +291,40 @@ class UnitTemplates {
         side = "resistance";
         infantry[] = {"MNP_Militia_Soldier_O", "MNP_Militia_Soldier_AR", "MNP_Militia_Soldier_F", "MNP_Militia_Soldier_RAT", "MNP_Militia_Soldier_MG", "MNP_Militia_Soldier_AR", "MNP_Militia_Soldier_RAT", "MNP_Militia_Soldier_AR", "MNP_Militia_Soldier_RAT"};
         crewmen[] = {"MNP_Militia_Soldier_F", "MNP_Militia_Soldier_O"};
-        technicals[] = {"B_G_Offroad_01_armed_F"};
-        armour[] = {"B_G_Offroad_01_armed_F"};
+        technicals[] = {"CUP_B_LR_MG_GB_W","CUP_O_UAZ_MG_CHDKZ","CUP_I_Datsun_PK","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_CHDKZ","CUP_I_Ural_ZU23_NAPA"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_I_T55_TK_GUE","CUP_O_T72_CHDKZ"};
     };
 
     class MNP_MIL_DE {
         side = "resistance";
         infantry[] = {"MNP_Militia_Soldier_DO", "MNP_Militia_Soldier_DAR", "MNP_Militia_Soldier_DF", "MNP_Militia_Soldier_DRAT", "MNP_Militia_Soldier_DMG", "MNP_Militia_Soldier_DAR", "MNP_Militia_Soldier_DRAT", "MNP_Militia_Soldier_DAR", "MNP_Militia_Soldier_DRAT"};
         crewmen[] = {"MNP_Militia_Soldier_DF", "MNP_Militia_Soldier_DO"};
-        technicals[] = {"B_G_Offroad_01_armed_F"};
-        armour[] = {"B_G_Offroad_01_armed_F"};
+        technicals[] = {"CUP_B_LR_MG_GB_W","CUP_O_UAZ_MG_CHDKZ","CUP_I_Datsun_PK","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_CHDKZ","CUP_I_Ural_ZU23_NAPA"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_I_T55_TK_GUE","CUP_O_T72_CHDKZ"};
     };
 
     class MNP_NPA_WD {
         side = "resistance";
         infantry[] = {"MNP_DPM_Soldier_O", "MNP_DPM_Soldier_AR", "MNP_DPM_Soldier_D", "MNP_DPM_Soldier_AT", "MNP_DPM_Soldier_MG", "MNP_DPM_Soldier_AR", "MNP_DPM_Soldier_AT", "MNP_DPM_Soldier_AR", "MNP_DPM_Soldier_AT"};
         crewmen[] = {"MNP_DPM_Soldier_D", "MNP_DPM_Soldier_O"};
-        technicals[] = {"B_G_Offroad_01_armed_F"};
-        armour[] = {"B_G_Offroad_01_armed_F"};
+        technicals[] = {"CUP_B_LR_MG_GB_W","CUP_O_UAZ_MG_CHDKZ","CUP_I_Datsun_PK","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_CHDKZ","CUP_I_Ural_ZU23_NAPA"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_I_T55_TK_GUE","CUP_O_T72_CHDKZ"};
     };
 
     class MNP_NPA_DE {
         side = "resistance";
         infantry[] = {"MNP_SixCo_Soldier_O", "MNP_SixCo_Soldier_AR", "MNP_SixCo_Soldier_D", "MNP_SixCo_Soldier_AT", "MNP_SixCo_Soldier_MG", "MNP_SixCo_Soldier_AR", "MNP_SixCo_Soldier_AT", "MNP_SixCo_Soldier_AR", "MNP_SixCo_Soldier_AT"};
         crewmen[] = {"MNP_SixCo_Soldier_D", "MNP_SixCo_Soldier_O"};
-        technicals[] = {"I_MRAP_03_hmg_F"};
-        armour[] = {"I_APC_tracked_03_cannon_F", "I_MBT_03_cannon_F"};
+        technicals[] = {"CUP_B_LR_MG_GB_W","CUP_O_UAZ_MG_CHDKZ","CUP_I_Datsun_PK","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_CHDKZ","CUP_I_Ural_ZU23_NAPA"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA","CUP_I_T55_TK_GUE","CUP_O_T72_CHDKZ"};
     };
 
     class MNP_ASA {
         side = "resistance";
         infantry[] = {"MNP_ASA_Soldier_O", "MNP_ASA_Soldier_AR", "MNP_ASA_Soldier_F", "MNP_ASA_Soldier_AT", "MNP_ASA_Soldier_MG", "MNP_ASA_Soldier_AR", "MNP_ASA_Soldier_AT", "MNP_ASA_Soldier_AR", "MNP_ASA_Soldier_AT"};
         crewmen[] = {"MNP_ASA_Soldier_F", "MNP_ASA_Soldier_O"};
-        technicals[] = {"B_G_Offroad_01_armed_F"};
-        armour[] = {"B_G_Offroad_01_armed_F"};
+        technicals[] = {"CUP_B_HMMWV_M1114_USMC","CUP_B_HMMWV_M1114_USMC","CUP_B_HMMWV_M2_USMC","CUP_B_HMMWV_M2_USMC","CUP_B_HMMWV_MK19_USMC"};
+        armour[] = {"CUP_B_M113_USA", "CUP_B_M113_USA","CUP_B_M163_USA","CUP_B_M1A1_Woodland_US_Army"};
     };
 
     class MNP_ARC {
@@ -363,16 +363,16 @@ class UnitTemplates {
         side = "resistance";
         infantry[] = {"MNP_FIN_Soldier_O", "MNP_FIN_Soldier_AR", "MNP_FIN_Soldier_F", "MNP_FIN_Soldier_AT", "MNP_FIN_Soldier_MG", "MNP_FIN_Soldier_AR", "MNP_FIN_Soldier_AT", "MNP_FIN_Soldier_AR", "MNP_FIN_Soldier_AT"};
         crewmen[] = {"MNP_FIN_Soldier_F", "MNP_FIN_Soldier_O"};
-        technicals[] = {"I_MRAP_03_hmg_F"};
-        armour[] = {"I_APC_tracked_03_cannon_F", "I_MBT_03_cannon_F"};
+        technicals[] = {"CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_RU"};
+        armour[] = {"CUP_O_BRDM2_SLA", "CUP_O_BRDM2_SLA", "CUP_O_T72_SLA"};
     };
 
     class MNP_FIN_SN {
         side = "resistance";
         infantry[] = {"MNP_AFIN_Soldier_O", "MNP_AFIN_Soldier_AR", "MNP_AFIN_Soldier_F", "MNP_AFIN_Soldier_AT", "MNP_AFIN_Soldier_MG", "MNP_AFIN_Soldier_AR", "MNP_AFIN_Soldier_AT", "MNP_AFIN_Soldier_AR", "MNP_AFIN_Soldier_AT"};
         crewmen[] = {"MNP_AFIN_Soldier_F", "MNP_AFIN_Soldier_O"};
-        technicals[] = {"I_MRAP_03_hmg_F"};
-        armour[] = {"I_APC_tracked_03_cannon_F", "I_MBT_03_cannon_F"};
+        technicals[] = {"CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_MG_RU","CUP_O_UAZ_AGS30_RU","CUP_O_UAZ_SPG9_RU"};
+        armour[] = {"CUP_O_BRDM2_SLA","CUP_O_BRDM2_SLA", "CUP_O_T72_SLA"};
     };
 
     class MNP_NOR_WD {
@@ -380,7 +380,7 @@ class UnitTemplates {
         infantry[] = {"MNP_NOR_Soldier_O", "MNP_NOR_Soldier_AR", "MNP_NOR_Soldier_F", "MNP_NOR_Soldier_AT", "MNP_NOR_Soldier_MG", "MNP_NOR_Soldier_AR", "MNP_NOR_Soldier_AT", "MNP_NOR_Soldier_AR", "MNP_NOR_Soldier_AT"};
         crewmen[] = {"MNP_NOR_Soldier_F", "MNP_NOR_Soldier_O"};
         technicals[] = {"I_MRAP_03_hmg_F"};
-        armour[] = {"I_APC_tracked_03_cannon_F", "I_MBT_03_cannon_F"};
+        armour[] = {"CUP_B_M113_USA", "CUP_B_M113_USA", "I_MBT_03_cannon_F"};
     };
 
     class MNP_NOR_DE {
@@ -388,7 +388,7 @@ class UnitTemplates {
         infantry[] = {"MNP_NOR_D_Soldier_O", "MNP_NOR_D_Soldier_AR", "MNP_NOR_D_Soldier_F", "MNP_NOR_D_Soldier_AT", "MNP_NOR_D_Soldier_MG", "MNP_NOR_D_Soldier_AR", "MNP_NOR_D_Soldier_AT", "MNP_NOR_D_Soldier_AR", "MNP_NOR_D_Soldier_AT"};
         crewmen[] = {"MNP_NOR_D_Soldier_F", "MNP_NOR_D_Soldier_O"};
         technicals[] = {"I_MRAP_03_hmg_F"};
-        armour[] = {"I_APC_tracked_03_cannon_F", "I_MBT_03_cannon_F"};
+        armour[] = {"CUP_B_M113_USA", "CUP_B_M113_USA", "I_MBT_03_cannon_F"};
     };
 
     class AAF_GUER {


### PR DESCRIPTION
Adding new Technical & Armour entries to default unit templates. Some
'reasonable' substitutions made where factions are lacking vehicles.