### PR TITLE
Adding camp base path unit

### DIFF
--- a/admiral/config.cpp
+++ b/admiral/config.cpp
@@ -29,7 +29,7 @@ class CfgFactionClasses {
         displayName = "Admiral";
     };
     class Admiral_Camps {
-	    displayName = "Admiral Waypoints";
+	    displayName = "Admiral Camp Bases";
 	    author = "Admiral";
 	    icon = "x\ark\addons\ark_inhouse\resources\ark_star.paa";
 	    priority = 1;
@@ -39,7 +39,7 @@ class CfgFactionClasses {
 
 class CfgVehicleClasses {
     class Admiral_Camps {
-        displayName = "Camp Path";
+        displayName = "Camp Bases";
     };
 };
 
@@ -50,7 +50,7 @@ class CfgVehicles {
 
     class C_Bob_VR : C_Soldier_VR_F {
         author = "Admiral";
-        displayName = "Camp Base Path";
+        displayName = "Camp Path Bases";
         faction = "Admiral";
         side = 3;
         vehicleClass = "Admiral_Camps";

--- a/admiral/config.cpp
+++ b/admiral/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = 1.0;
-        requiredAddons[] = {"CBA_MAIN"};
+        requiredAddons[] = {"CBA_MAIN", "A3_Characters_F_Common", "A3_Characters_F"};
         author[] = {"Kami", "Cam", "Ark"};
         authorUrl = "https://github.com/kami-";
     };
@@ -28,10 +28,33 @@ class CfgFactionClasses {
     class Admiral : NO_CATEGORY {
         displayName = "Admiral";
     };
+    class Admiral_Camps {
+	    displayName = "Admiral Waypoints";
+	    author = "Admiral";
+	    icon = "x\ark\addons\ark_inhouse\resources\ark_star.paa";
+	    priority = 1;
+	    side = 3;
+	};
+};
+
+class CfgVehicleClasses {
+    class Admiral_Camps {
+        displayName = "Camp Path";
+    };
 };
 
 class CfgVehicles {
     #include "admiral_modules.h"
+
+    class C_Soldier_VR_F;
+
+    class C_Bob_VR : C_Soldier_VR_F {
+        author = "Admiral";
+        displayName = "Camp Base Path";
+        faction = "Admiral";
+        side = 3;
+        vehicleClass = "Admiral_Camps";
+    };
 };
 
 #include "admiral.h"

--- a/admiral/config.cpp
+++ b/admiral/config.cpp
@@ -50,7 +50,7 @@ class CfgVehicles {
 
     class C_Bob_VR : C_Soldier_VR_F {
         author = "Admiral";
-        displayName = "Camp Path Bases";
+        displayName = "Camp Path Base";
         faction = "Admiral";
         side = 3;
         vehicleClass = "Admiral_Camps";


### PR DESCRIPTION
RPT clean and should work when admiral is upated to use the new classname ```C_Bob_VR```.

This adds a dependancy on ARK Scripts for the icon, easy enough to move/migrate at a later date if required.

To do:
Look at adding parameters to Bob so you can define infantry/technical/armour only paths.