### PR TITLE
Disabling FFV slots dismounting under combat by default

### DIFF
--- a/admiral/admiral.h
+++ b/admiral/admiral.h
@@ -7,6 +7,7 @@ class Admiral {
     isBehaviorEnabled = 1;
     canSpawnOnRoof = 1;
     allowCrewInImmobile = 1;
+    cargoUnloadInCombat = 0;
     transferNonPlayableGroupsToHc = 1; // Non-playable groups are that do not have playable units in them
     groupSpawnDelay = 5; // Delay in seconds between spawning groups
 

--- a/admiral/common_functions.sqf
+++ b/admiral/common_functions.sqf
@@ -54,6 +54,7 @@ adm_common_fnc_placeVehicle = {
     _vehicle = createVehicle [_className, _vehiclePosition, [], 0, "NONE"];
     _vehicle setVariable ["adm_classNameArguments", _classNameArguments, false];
     _vehicle allowCrewInImmobile adm_allowCrewInImmobile;
+    _vehicle setUnloadInCombat [adm_cargoUnloadInCombat, false];
     DEBUG("admiral.common.create",FMT_4("Created vehicle '%1' at position '%2', with classname '%3' and '%4'.",_vehicle,_vehiclePosition,_className,_classNameArguments));
 
     _vehicle;

--- a/admiral/settings_functions.sqf
+++ b/admiral/settings_functions.sqf
@@ -57,6 +57,7 @@ adm_settings_fnc_init = {
     adm_isBehaviorEnabled = ["isBehaviorEnabled"] call adm_config_fnc_getBool;
     adm_canSpawnOnRoof = ["canSpawnOnRoof"] call adm_config_fnc_getBool;
     adm_allowCrewInImmobile = ["allowCrewInImmobile"] call adm_config_fnc_getBool;
+    adm_cargoUnloadInCombat = ["cargoUnloadInCombat"] call adm_config_fnc_getBool;
     adm_groupSpawnDelay = ["groupSpawnDelay"] call adm_config_fnc_getNumber;
     adm_lastGroupSpawnTime = 0;
 


### PR DESCRIPTION
When you allow FFV turrets to be filled, once the vehicle takes fire, it stops to dismount everyone but then doesn't progress on as the group leader is still in the vehicle. Generally causes weird and stupid behaviour, while slightly unrealistic, this is the better of the two options.

I've left it as an option so a mission maker can still re-enable this behaviour if there is a weird edge case I'm missing.