### PR TITLE
Stopping CQC units dancing

### DIFF
--- a/admiral/cqc_functions.sqf
+++ b/admiral/cqc_functions.sqf
@@ -27,8 +27,8 @@ adm_cqc_fnc_initMan = {
     DECLARE(_wp) = [_group, [getPosATL _unit, 0], 'GUARD', 'AWARE', 'RED'] call adm_common_fnc_createWaypoint;
     _group setCurrentWaypoint _wp;
     _unit setDir (random 360);
-    {_unit disableAI _x} forEach ["PATH", "FSM", "COVER"];
-    _unit setUnitPos 'UP';
+    _unit disableAI "FSM";
+    doStop _unit;
 };
 
 adm_cqc_fnc_getBuildingPositions = {


### PR DESCRIPTION
Reference from the CBA issue where there garrison module had the same problem, looks to be an issue with setUnitPos and disabling pathing. Reverting to the old A2 way!

This might mean CQC units leave buildings intermittently, we'll see...