### PR TITLE
Switch back to disableAI PATH

### DIFF
--- a/admiral/cqc_functions.sqf
+++ b/admiral/cqc_functions.sqf
@@ -27,8 +27,7 @@ adm_cqc_fnc_initMan = {
     DECLARE(_wp) = [_group, [getPosATL _unit, 0], 'GUARD', 'AWARE', 'RED'] call adm_common_fnc_createWaypoint;
     _group setCurrentWaypoint _wp;
     _unit setDir (random 360);
-    _unit disableAI "FSM";
-    doStop _unit;
+    {_unit disableAI _x} forEach ["FSM","PATH"];
 };
 
 adm_cqc_fnc_getBuildingPositions = {


### PR DESCRIPTION
So we originally switched away from this to stop units going prone and shooting through walls/floors etc. While this will bring back this behaviour, it's preferable over the current issue which is basically all CQC units leave their positions so when we arrive at objectives, they're basically empty.

I will look in to the formationDanger.FSM to see if I can kill this prone bullshit at the lowest level in the future...