### PR TITLE
Removing bis_fnc_initVeh

### DIFF
--- a/admiral/common_functions.sqf
+++ b/admiral/common_functions.sqf
@@ -52,7 +52,6 @@ adm_common_fnc_placeVehicle = {
     };
     private _vehiclePosition = [_area, _position, _className] call adm_common_fnc_getRandomEmptyPositionInArea;
     private _vehicle = createVehicle [_className, _vehiclePosition, [], 0, "NONE"];
-    [_vehicle, true, true, true] call bis_fnc_initVehicle;
     _vehicle setVariable ["adm_classNameArguments", _classNameArguments, false];
     _vehicle allowCrewInImmobile adm_allowCrewInImmobile;
     _vehicle setUnloadInCombat [adm_cargoUnloadInCombat, false];


### PR DESCRIPTION
Originally enabled here: https://github.com/kami-/admiral/commit/59d872a07aaf3a7ce37f113250b128f62549b537#diff-7e2086b864aab8b7b8854f089692dc96

We did this to stop the randomisation of BI vehicles (missing doors on vanilla technicals etc), however some of the CUP vehicles, notably Winter chally 2 `CUP_B_Challenger2_2CS_BAF` it resets to the default textures when this code is run. It's probably impacting more classes but we've not noticed.

I did remember an issue with CUP UAZs and them using the incorrect texture which I thought was related but I had spawned 10 different versions and manually ran bis_fnc_initVehicle and non of them changed so maybe that wasn't related to why we added this fix!