### PR TITLE
Filter grpNull in debug

### DIFF
--- a/admiral/debug_functions.sqf
+++ b/admiral/debug_functions.sqf
@@ -26,7 +26,7 @@ adm_debug_fnc_createMovingGroupMarkers = {
 adm_debug_fnc_updateMovingGroupMarkers = {
     params ["_group"];
 
-    DECLARE(_debugMarkers) = _group getVariable "adm_group_debugMarkers";
+    private _debugMarkers = _group getVariable "adm_group_debugMarkers";
     if (IS_GROUP_ALIVE(_group)) then {
         if (!isNil {_debugMarkers}) then {
             [_group, _debugMarkers] call adm_debug_fnc_updateMovingGroupWaypointMarkers;
@@ -53,7 +53,7 @@ adm_debug_fnc_updateMovingGroupWaypointMarkers = {
 adm_debug_fnc_updateMovingGroupsStateMarkers = {
    params ["_group","_lineMarker"];
 
-    DECLARE(_state) = _group getVariable ["adm_behavior_state", STATE_INIT];
+    private _state = _group getVariable ["adm_behavior_state", STATE_INIT];
     call {
         if (_state in [STATE_INIT, STATE_MOVING]) exitwith {
             _lineMarker setMarkerAlphaLocal 0;
@@ -74,9 +74,9 @@ adm_debug_fnc_updateMovingGroupsStateMarkers = {
 
 adm_debug_fnc_deleteAllMovingGroupMarkers = {
     {
-        DECLARE(_groups) = _x;
+        private _groups = _x;
         {
-            DECLARE(_debugMarkers) = _x getVariable "adm_group_debugMarkers";
+            private _debugMarkers = _x getVariable "adm_group_debugMarkers";
             if (!isNil {_debugMarkers}) then {
                 [_x, _debugMarkers] call adm_debug_fnc_deleteMovingGroupMarkers;
             };
@@ -97,7 +97,7 @@ adm_debug_fnc_deleteMovingGroupMarkers = {
 adm_debug_fnc_createCqcUnitMarker = {
    params ["_unit","_group"];
 
-    DECLARE(_debugMarker) = [format ["adm_unit_cqc_%1", _unit], getPosATL _unit, "ICON", CQC_DEBUG_MARKER, [side _group] call adm_debug_fnc_getSideColor, CQC_DEBUG_MARKER_SIZE] call adm_common_fnc_createLocalMarker;
+    private _debugMarker = [format ["adm_unit_cqc_%1", _unit], getPosATL _unit, "ICON", CQC_DEBUG_MARKER, [side _group] call adm_debug_fnc_getSideColor, CQC_DEBUG_MARKER_SIZE] call adm_common_fnc_createLocalMarker;
     _unit setVariable ["adm_unit_debugMarker", _debugMarker, false];
     DEBUG("admiral.debug",FMT_3("Created CQC unit marker '%1' for unit '%2' in group '%3'.",_debugMarker,_unit,_group));
 
@@ -116,7 +116,7 @@ adm_debug_fnc_updateCqcGroupMarkers = {
     params ["_group"];
 
     {
-        DECLARE(_debugMarker) = _x getVariable "adm_unit_debugMarker";
+        private _debugMarker = _x getVariable "adm_unit_debugMarker";
         if (!isNil {_debugMarker}) then {
             if (alive _x) then {
                 _debugMarker setMarkerPosLocal (getPosATL _x);
@@ -138,9 +138,9 @@ adm_debug_fnc_updateCqcGroupMarkers = {
 
 adm_debug_fnc_deleteAllCqcGroupMarkers = {
     {
-        DECLARE(_group) = _x;
+        private _group = _x;
         {
-            DECLARE(_debugMarker) = _x getVariable "adm_unit_debugMarker";
+            private _debugMarker = _x getVariable "adm_unit_debugMarker";
             if (!isNil {_debugMarker}) then {
                 [_x, _debugMarker] call adm_debug_fnc_deleteCqcUnitMarker;
             } else {
@@ -152,7 +152,7 @@ adm_debug_fnc_deleteAllCqcGroupMarkers = {
 adm_debug_fnc_updateZoneMarkers = {
     params ["_zone"];
 
-    DECLARE(_debugMarker) = GET_ZONE_DEBUG_MARKER(_zone);
+    private _debugMarker = GET_ZONE_DEBUG_MARKER(_zone);
     if (_debugMarker != "") then {
 
     } else {
@@ -166,7 +166,7 @@ adm_debug_fnc_updateZoneMarkers = {
 adm_debug_fnc_deleteZoneMarkers = {
     params ["_zone"];
 
-    DECLARE(_debugMarker) = GET_ZONE_DEBUG_MARKER(_zone);
+    private _debugMarker = GET_ZONE_DEBUG_MARKER(_zone);
     if (_debugMarker != "") then {
         deleteMarkerLocal _debugMarker;
         if (GET_ZONE_TYPE(_zone) == "camp") then {
@@ -180,7 +180,7 @@ adm_debug_fnc_deleteZoneMarkers = {
 
 adm_debug_fnc_deleteAllZoneMarkers = {
     {
-        DECLARE(_zones) = _x;
+        private _zones = _x;
         {
             [_x] call adm_debug_fnc_deleteZoneMarkers;
         } foreach _zones;
@@ -230,7 +230,7 @@ adm_debug_fnc_createTriggerMarker = {
 adm_debug_fnc_createAllCampPathMarkers = {
     params ["_zone"];
 
-    DECLARE(_paths) = GET_CAMP_PATHS(_zone);
+    private _paths = GET_CAMP_PATHS(_zone);
     {
         if (isNil {GET_PATH_DEBUG_MARKERS(_x)}) then {
             [_x] call adm_debug_fnc_createCampPathMarkers;
@@ -260,7 +260,7 @@ adm_debug_fnc_createCampPathMarkers = {
 adm_debug_fnc_deleteCampPathMarkers = {
     params ["_path"];
 
-    DECLARE(_debugMarkers) = GET_PATH_DEBUG_MARKERS(_path);
+    private _debugMarkers = GET_PATH_DEBUG_MARKERS(_path);
     if (!isNil {_debugMarkers}) then {
         {
             deleteMarkerLocal _x;
@@ -317,7 +317,7 @@ adm_debug_fnc_createDebugFactionCounterMarkers = {
 };
 
 adm_debug_fnc_createAllDebugCounterMarkers = {
-    DECLARE(_xPos) = COUNTER_DEBUG_MARKER_X_POS;
+    private _xPos = COUNTER_DEBUG_MARKER_X_POS;
     {
         [_x, _xPos] call adm_debug_fnc_createDebugFactionCounterMarkers;
         _xPos = _xPos + (4 * COUNTER_DEBUG_MARKER_X_INCREMENT);
@@ -334,7 +334,7 @@ adm_debug_fnc_updateDebugCounterMarkers = {
         [[adm_patrol_armourGroups, adm_camp_armourGroups], adm_common_fnc_getAliveSideGroups]
     ];
     {
-        DECLARE(_count) = [_groupTypeCountArray select _forEachIndex select 0, _side] call (_groupTypeCountArray select _forEachIndex select 1);
+        private _count = [_groupTypeCountArray select _forEachIndex select 0, _side] call (_groupTypeCountArray select _forEachIndex select 1);
         (format ["adm_counter_%1_%2", _side, _x]) setMarkerTextLocal str count _count;
     } foreach GROUP_TYPE_DEBUG_MARKERS;
     (format ["adm_counter_%1_total", _side]) setMarkerTextLocal format ["%1 (%2)", count (([_side] call adm_common_fnc_getAllAliveSideUnits) select {simulationEnabled _x}), count ([_side] call adm_common_fnc_getAllAliveSideUnits)];
@@ -349,7 +349,7 @@ adm_debug_fnc_updateAllDebugCounterMarkers = {
 
 adm_debug_fnc_deleteAllDebugCounterMarkers = {
     {
-        DECLARE(_side) = _x;
+        private _side = _x;
         {
             deleteMarkerLocal format ["adm_counter_%1_%2", _side, _x];
         } foreach GROUP_TYPE_DEBUG_MARKERS;
@@ -360,7 +360,7 @@ adm_debug_fnc_deleteAllDebugCounterMarkers = {
 adm_debug_fnc_getSideColor = {
     params ["_side"];
 
-    DECLARE(_index) = SIDE_ARRAY find _side;
+    private _index = SIDE_ARRAY find _side;
     if (_index >= 0) then {
         SIDE_DEBUG_MARKER_COLORS select _index;
     } else {
@@ -386,9 +386,14 @@ adm_debug_fnc_debugMonitor = {
 
 adm_debug_fnc_debugGroups = {
     {
-        DECLARE(_groups) = _x;
+
+        private _groups = _x;
         {
-            [_x] call adm_debug_fnc_updateMovingGroupMarkers;
+            if (isNull _x) then {
+                _groups deleteAt (_groups find _x);
+            } else {
+                [_x] call adm_debug_fnc_updateMovingGroupMarkers;
+            };
         } foreach _groups;
     } foreach MOVING_GROUPS;
     {
@@ -399,7 +404,7 @@ adm_debug_fnc_debugGroups = {
 
 adm_debug_fnc_debugZones = {
     {
-        DECLARE(_zones) = _x;
+        private _zones = _x;
         {
             [_x] call adm_debug_fnc_updateZoneMarkers;
         } foreach _zones;


### PR DESCRIPTION
I think some engine bits changed in `getVariable` as debug now complains when it's passed empty groups.

E.g.

```
11:36:04 getVariable called on null group
11:36:04  ➥ Context: 	[] L374 (x\ark\addons\admiral\debug_functions.sqf)
	[] L375 (x\ark\addons\admiral\debug_functions.sqf)
	[] L393 (x\ark\addons\admiral\debug_functions.sqf)
	[] L392 (x\ark\addons\admiral\debug_functions.sqf)
	[] L391 (x\ark\addons\admiral\debug_functions.sqf)
	[] L29 (x\ark\addons\admiral\debug_functions.sqf)
```

Added some filtering and cleanup to the debug fnc, tested in local MP, seems to stop the RPT errors and arrays look clean. Also moved to inline privates as it's easier to debug in console without macros.

Main change is here https://github.com/kami-/admiral/compare/master...Cyruz143:admiral:master#diff-b709790ce3dc041261d699cf1bc6301c2d7a9d7e10b08bea6cf337709c489c85R390-R396. 